### PR TITLE
Update tmbundle pipeline to properly create releases

### DIFF
--- a/.github/workflows/tmbundle.yml
+++ b/.github/workflows/tmbundle.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v2
 
@@ -21,19 +24,13 @@ jobs:
     - name: Install vsce
       run: npm install -g @vscode/vsce
 
+    - name: Package .vsix
+      run: cd plush.tmbundle && vsce package
+
     - name: Extract version
       run: echo "TAG=$(jq -r '.version' plush.tmbundle/package.json)" >> $GITHUB_ENV
 
-    - name: Create tag
-      run: |
-        git tag $TAG
-        git push origin $TAG
-
-    - name: Package .vsix
-      run: cd tmbundle && vsce package
-
     - name: Create Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ env.TAG }}
-        files: plush.tmbundle/*.vsix
+      run: gh release create $TAG 'plush.tmbundle/*.vsix' --generate-notes
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Addresses the workflow issue after merging #15 

- Explicitly gave write permissions to `GITHUB_TOKEN`
- Swapped the release step to use GitHub CLI for simplicity
- Added .vscodeignore to suppress a warning (see below)

`Neither a .vscodeignore file nor a "files" property in package.json was found. To ensure only necessary files are included in your extension, add a .vscodeignore file or specify the "files" property in package.json. More info: https://aka.ms/vscode-vscodeignore`

Sample successful workflow: https://github.com/farooqameen/plush/actions/runs/17597683802/job/49993455862