### PR TITLE
Implement strings natively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .vscode
 SDL2.dll
 TODO.txt
+.zed

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -327,7 +327,7 @@ impl ExprBox
             Expr::HostFn(f) => code.push(Insn::push { val: Value::HostFn(*f) }),
 
             Expr::String(s) => {
-                code.push(Insn::push { val: alloc.str_val(s.clone()) });
+                code.push(Insn::push { val: alloc.str_val(&s) });
             }
 
             Expr::ByteArray(bytes) => {
@@ -367,7 +367,7 @@ impl ExprBox
 
             Expr::Member { base, field } => {
                 base.gen_code(fun, code, alloc)?;
-                let field = alloc.str(field.clone());
+                let field = alloc.str(&field);
                 code.push(Insn::get_field {
                     field,
                     class_id: Default::default(),
@@ -446,7 +446,7 @@ impl ExprBox
                             arg.gen_code(fun, code, alloc)?;
                         }
 
-                        let name = alloc.str(field.clone());
+                        let name = alloc.str(&field);
                         code.push(Insn::call_method { name, argc });
                     }
 
@@ -541,7 +541,7 @@ fn gen_dict_expr(
 
         expr.gen_code(fun, code, alloc)?;
 
-        let field_name = alloc.str(name.clone());
+        let field_name = alloc.str(&name);
 
         code.push(Insn::set_field {
             field: field_name,
@@ -783,7 +783,7 @@ fn gen_assign(
         }
 
         Expr::Member { base, field } => {
-            let field = alloc.str(field.to_string());
+            let field = alloc.str(&field);
 
             if need_value {
                 rhs.gen_code(fun, code, alloc)?;

--- a/src/deepcopy.rs
+++ b/src/deepcopy.rs
@@ -18,7 +18,7 @@ impl Hash for Value
             String(ptr) => {
                 // Hash the string
                 // This will deduplicate identical strings
-                let s: &str = unsafe { &**ptr };
+                let s: &str = unsafe { (**ptr).as_str() };
                 s.hash(state);
             },
 
@@ -89,8 +89,7 @@ pub fn deepcopy(
 
         let new_val = match val {
             Value::String(p) => {
-                let new_str = dst_alloc.alloc(unsafe { (*p).clone() });
-                Value::String(new_str)
+                dst_alloc.str_val(unsafe { (*p).as_str() })
             }
 
             Value::Closure(p) => {
@@ -226,7 +225,7 @@ mod tests
         let mut src_alloc = Alloc::new();
         let mut dst_alloc = Alloc::new();
         let mut dst_map = HashMap::new();
-        let s1 = src_alloc.str_val("foo".to_string());
+        let s1 = src_alloc.str_val("foo");
         let s2 = deepcopy(s1, &mut dst_alloc, &mut dst_map);
         assert!(s1 == s2);
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -166,7 +166,7 @@ pub fn cmd_get_arg(actor: &mut Actor, idx: Value) -> Result<Value, String>
         return Ok(Value::Nil);
     }
 
-    Ok(actor.alloc.str_val(args[idx].clone()))
+    Ok(actor.alloc.str_val(&args[idx]))
 }
 
 /// Print a value to stdout
@@ -206,7 +206,7 @@ fn readln(actor: &mut Actor) -> Result<Value, String>
 
     match std::io::stdin().read_line(&mut line) {
         Ok(_) => {
-            Ok(actor.alloc.str_val(line))
+            Ok(actor.alloc.str_val(&line))
         }
 
         Err(_) => Ok(Value::Nil)
@@ -367,7 +367,7 @@ fn read_file_utf8(actor: &mut Actor, file_path: Value) -> Result<Value, String>
         Ok(s) => s
     };
 
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 /// Writes the contents of a ByteArray to a file

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod deepcopy;
 mod window;
 mod audio;
 mod exec_tests;
+mod str;
 
 extern crate sdl2;
 use std::env;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,17 +9,17 @@ fn identity_method(actor: &mut Actor, self_val: Value) -> Result<Value, String>
 
 fn true_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
-    Ok(actor.alloc.str_val("true".to_string()))
+    Ok(actor.alloc.str_val("true"))
 }
 
 fn false_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
-    Ok(actor.alloc.str_val("false".to_string()))
+    Ok(actor.alloc.str_val("false"))
 }
 
 fn nil_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
-    Ok(actor.alloc.str_val("nil".to_string()))
+    Ok(actor.alloc.str_val("nil"))
 }
 
 fn int64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
@@ -52,7 +52,7 @@ fn int64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = v.unwrap_i64();
     let s = format!("{}", v);
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 fn float64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
@@ -160,7 +160,7 @@ fn float64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = v.unwrap_f64();
     let s = format!("{}", v);
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 fn float64_format_decimals(actor: &mut Actor, v: Value, decimals: Value) -> Result<Value, String>
@@ -168,7 +168,7 @@ fn float64_format_decimals(actor: &mut Actor, v: Value, decimals: Value) -> Resu
     let num = v.unwrap_f64();
     let decimals = unwrap_usize!(decimals);
     let s = format!("{:.*}", decimals, num);
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 /// Create a single-character string from a codepoint integer value
@@ -184,7 +184,7 @@ fn string_from_codepoint(actor: &mut Actor, _class: Value, codepoint: Value) -> 
     let mut s = String::new();
     s.push(ch);
 
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 /// Get the UTF-8 byte at the given index
@@ -220,7 +220,7 @@ fn string_char_at(actor: &mut Actor, s: Value, byte_idx: Value) -> Result<Value,
         Some(ch) => ch,
     };
 
-    Ok(actor.alloc.str_val(ch.to_string()))
+    Ok(actor.alloc.str_val(&ch.to_string()))
 }
 
 /// Try to parse the string as an integer with the given radix
@@ -240,7 +240,7 @@ fn string_trim(actor: &mut Actor, s: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let s = s.trim().to_string();
-    Ok(actor.alloc.str_val(s))
+    Ok(actor.alloc.str_val(&s))
 }
 
 /// Split a string by a separator and return an array of strings
@@ -250,7 +250,7 @@ fn string_split(actor: &mut Actor, s: Value, sep: Value) -> Result<Value, String
     let sep = unwrap_str!(sep);
 
     let parts: Vec<Value> = s.split(sep).map(|part| {
-        actor.alloc.str_val(part.to_string())
+        actor.alloc.str_val(&part.to_string())
     }).collect();
 
     let arr = crate::array::Array { elems: parts };

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Str(*const str);
+
+impl Str {
+    pub fn new(s: *const str) -> Self {
+        Str(s)
+    }
+
+    pub fn as_str(&self) -> &str {
+        unsafe { &*self.0 }
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -300,7 +300,7 @@ pub fn poll_ui_msg(actor: &mut Actor) -> Option<Value>
             actor.set_field(msg, "window_id", Value::from(0));
             let kind = actor.intern_str("TEXT_INPUT");
             actor.set_field(msg, "kind", kind);
-            let text = actor.alloc.str_val(text);
+            let text = actor.alloc.str_val(&text);
             actor.set_field(msg, "text", text);
 
             Some(msg)


### PR DESCRIPTION
this commit makes it so that string are allocated on the vm allocator rather than being managed by Rust `String`s.

this is necessary for future GC efforts, but also just further consolidate the `Alloc` struct as the place where we allocate memory (this also a nice perf win, as `Alloc` is essentially a bump allocator, so even strings get that perf boost from this)