### PR TITLE
Refactor Plush to use a register-based interpreter, for SIIIICK performance gains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,9 @@
-Avoid overcommenting:
-- Keep comments concise and relevant in lexical context
-- Avoid long multi-line comments
+Commenting:
+- Avoid overcommenting:
+  - Keep comments concise and relevant in lexical context
+  - Avoid long multi-line comments
+- Comments should start with an uppercase letter, e.g.
+  // This is a comment
 
 When making file edits of any kind, prefer using tools rather than running
 shell commands, as shell commands hide the file edits from the user.

--- a/benchmarks/fft.psh
+++ b/benchmarks/fft.psh
@@ -16,13 +16,13 @@ fun fft(real_parts, imag_parts, inverse) {
         if (j > i) {
             // Swap real parts
             let temp_re = real_parts.get_f32(i);
-            real_parts.store_f32(i, real_parts.get_f32(j));
-            real_parts.store_f32(j, temp_re);
+            real_parts.set_f32(i, real_parts.get_f32(j));
+            real_parts.set_f32(j, temp_re);
 
             // Swap imaginary parts
             let temp_im = imag_parts.get_f32(i);
-            imag_parts.store_f32(i, imag_parts.get_f32(j));
-            imag_parts.store_f32(j, temp_im);
+            imag_parts.set_f32(i, imag_parts.get_f32(j));
+            imag_parts.set_f32(j, temp_im);
         }
         let var m = n _/ 2;
         while (m >= 1 && j >= m) {
@@ -60,12 +60,12 @@ fun fft(real_parts, imag_parts, inverse) {
                 let v_im = x_half_re * w_im + x_half_im * w_re;
 
                 // x[i + j] = u + v
-                real_parts.store_f32(i + j, u_re + v_re);
-                imag_parts.store_f32(i + j, u_im + v_im);
+                real_parts.set_f32(i + j, u_re + v_re);
+                imag_parts.set_f32(i + j, u_im + v_im);
 
                 // x[i + j + len / 2] = u - v
-                real_parts.store_f32(i + j + len _/ 2, u_re - v_re);
-                imag_parts.store_f32(i + j + len _/ 2, u_im - v_im);
+                real_parts.set_f32(i + j + len _/ 2, u_re - v_re);
+                imag_parts.set_f32(i + j + len _/ 2, u_im - v_im);
 
                 // w = w * wlen
                 let next_w_re = w_re * wlen_re - w_im * wlen_im;
@@ -83,8 +83,8 @@ fun fft(real_parts, imag_parts, inverse) {
     // Apply 1/N factor for inverse FFT
     if (inverse) {
         for (let var k = 0; k < n; ++k) {
-            real_parts.store_f32(k, real_parts.get_f32(k) / n);
-            imag_parts.store_f32(k, imag_parts.get_f32(k) / n);
+            real_parts.set_f32(k, real_parts.get_f32(k) / n);
+            imag_parts.set_f32(k, imag_parts.get_f32(k) / n);
         }
     }
 }
@@ -102,17 +102,44 @@ fun main() {
     for (let var i = 0; i < N; ++i) {
         // Generate a sine wave
         let value = (2.0 * PI * frequency * (i / sample_rate)).sin();
-        real_parts.store_f32(i, value);
-        imag_parts.store_f32(i, 0.0);
+        real_parts.set_f32(i, value);
+        imag_parts.set_f32(i, 0.0);
     }
 
-    // --- Benchmark FFT ---
-    let start_time = $time_current_ms();
-    fft(real_parts, imag_parts, false); // Compute forward FFT
-    let end_time = $time_current_ms();
-    let fft_time = end_time - start_time;
+    // One transform is short enough that process startup would dominate a
+    // wall clock measurement, so the timed section repeats it. Each
+    // iteration is a forward transform followed by its inverse, which
+    // brings the data back to where it started instead of letting the
+    // magnitudes grow without the 1/N factor the inverse applies
+    let NUM_ITERS = 1470;
 
-    $println("FFT of " + N.to_s() + " samples took: " + fft_time.to_s() + " ms");
+    let start_time = $time_current_ms();
+
+    for (let var iter = 0; iter < NUM_ITERS; ++iter) {
+        fft(real_parts, imag_parts, false); // Compute forward FFT
+        fft(real_parts, imag_parts, true);  // Compute inverse FFT
+    }
+
+    let end_time = $time_current_ms();
+    let total_time = end_time - start_time;
+    let per_iter = total_time.to_f() / NUM_ITERS.to_f();
+
+    $println(
+        "FFT of " + N.to_s() + " samples took: " + total_time.to_s() + " ms for " +
+        NUM_ITERS.to_s() + " forward/inverse pairs, " +
+        per_iter.format_decimals(3) + " ms per pair"
+    );
+
+    // The round trip should reproduce the input, so this is a check that
+    // the transform did not drift into nonsense over the iterations
+    let value0 = (2.0 * PI * frequency * (0 / sample_rate)).sin();
+    let value1 = (2.0 * PI * frequency * (1 / sample_rate)).sin();
+    $println(
+        "round trip check: " + real_parts.get_f32(0).format_decimals(4) +
+        " (expected " + value0.format_decimals(4) + "), " +
+        real_parts.get_f32(1).format_decimals(4) +
+        " (expected " + value1.format_decimals(4) + ")"
+    );
 
     /*
     // Optional: Print first few FFT results (magnitude)
@@ -125,23 +152,6 @@ fun main() {
     }
     */
 
-    // --- Benchmark Inverse FFT ---
-    // Re-initialize input for IFFT if you want to test it independently
-    // For now, we'll just run IFFT on the result of the forward FFT
-    let start_time_ifft = $time_current_ms();
-    fft(real_parts, imag_parts, true); // Compute inverse FFT
-    let end_time_ifft = $time_current_ms();
-    let ifft_time = end_time_ifft - start_time_ifft;
-
-    $println("Inverse FFT of " + N.to_s() + " samples took: " + ifft_time.to_s() + " ms");
-
-    /*
-    // Optional: Print first few IFFT results (real part)
-    $println("First 20 IFFT real parts:");
-    for (let var i = 0; i < 20; ++i) {
-        $println("  " + i.to_f().to_s() + ": " + real_parts.get_f32(i).format_decimals(4));
-    }
-    */
 }
 
 main();

--- a/benchmarks/matrix_vec_mult.psh
+++ b/benchmarks/matrix_vec_mult.psh
@@ -30,18 +30,28 @@ for (let var i = 0; i < num_inputs; ++i) {
 
 let result = Array.with_size(num_outputs, 0);
 
+// One multiplication is short enough that process startup would dominate
+// a wall clock measurement, so the timed section repeats it
+let NUM_ITERS = 340;
+
 // Perform matrix-vector multiplication
 let start_time = $time_current_ms();
 
-for (let var i = 0; i < num_outputs; ++i) {
-    let var sum = 0.0;
-    for (let var j = 0; j < num_inputs; ++j) {
-        sum = sum + matrix[i][j] * vector[j];
+for (let var iter = 0; iter < NUM_ITERS; ++iter) {
+    for (let var i = 0; i < num_outputs; ++i) {
+        let var sum = 0.0;
+        for (let var j = 0; j < num_inputs; ++j) {
+            sum = sum + matrix[i][j] * vector[j];
+        }
+        result[i] = sum;
     }
-    result[i] = sum;
 }
 
 let end_time = $time_current_ms();
 let elapsed_ms = end_time - start_time;
+let per_iter = elapsed_ms.to_f() / NUM_ITERS.to_f();
 
-$println("Matrix-vector multiplication took " + elapsed_ms.to_s() + " ms.");
+$println(
+    "Matrix-vector multiplication took " + elapsed_ms.to_s() + " ms for " +
+    NUM_ITERS.to_s() + " iterations, " + per_iter.format_decimals(3) + " ms per iteration."
+);

--- a/benchmarks/sha256.psh
+++ b/benchmarks/sha256.psh
@@ -144,7 +144,7 @@ fun main() {
     }
 
     // Hash a buffer filled with a simple byte pattern
-    let NUM_BYTES = 1536 * 1024;
+    let NUM_BYTES = 8 * 1536 * 1024;
     let data = ByteArray.with_size(NUM_BYTES);
     for (let var i = 0; i < NUM_BYTES; ++i) {
         data[i] = i & 0xFF;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use crate::lexer::SrcPos;
 use crate::symbols::Decl;
-use crate::host::HostFn;
+use crate::host::HostFnId;
 
 /// Unary operator
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -59,7 +59,7 @@ pub enum Expr
     String(String),
 
     // Host function
-    HostFn(&'static HostFn),
+    HostFn(HostFnId),
 
     // ByteArray literal
     ByteArray(Vec<u8>),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -17,6 +17,15 @@ pub struct CompiledFun
     pub num_locals: usize,
 }
 
+/// Emit a push of a heap constant. The value moves into the actor's
+/// constant pool, which roots it, so nothing later in codegen has to
+/// keep it alive across an allocation
+fn gen_const(val: Value, actor: &mut Actor)
+{
+    let idx = actor.push_const(val);
+    actor.insns.push(Insn::push_const { idx });
+}
+
 // Patch a jump instruction
 fn patch_jump(code: &mut Vec<Insn>, jmp_idx: usize, dst_idx: usize)
 {
@@ -328,33 +337,34 @@ impl ExprBox
             Expr::HostFn(f) => actor.insns.push(Insn::push { val: Value::host_fn(*f) }),
 
             // Constants that don't fit in an immediate are boxed in the
-            // heap the code is compiled for, and traced from there
+            // heap the code is compiled for, and held by the constant
+            // pool, which is what the collector traces them from
             Expr::Int64(v) => {
-                let val = match Value::try_fixnum(*v) {
-                    Some(val) => val,
+                match Value::try_fixnum(*v) {
+                    Some(val) => actor.insns.push(Insn::push { val }),
                     None => {
                         actor.gc_check(HEADER_SIZE + size_of::<i64>(), &mut []);
-                        actor.alloc.heap_int64(*v)
+                        let val = actor.alloc.heap_int64(*v);
+                        gen_const(val, actor);
                     }
-                };
-                actor.insns.push(Insn::push { val });
+                }
             }
 
             Expr::Float64(v) => {
-                let val = match Value::try_flonum(*v) {
-                    Some(val) => val,
+                match Value::try_flonum(*v) {
+                    Some(val) => actor.insns.push(Insn::push { val }),
                     None => {
                         actor.gc_check(HEADER_SIZE + size_of::<f64>(), &mut []);
-                        actor.alloc.heap_float64(*v)
+                        let val = actor.alloc.heap_float64(*v);
+                        gen_const(val, actor);
                     }
-                };
-                actor.insns.push(Insn::push { val });
+                }
             }
 
             Expr::String(s) => {
                 actor.gc_check(Str::alloc_size(s.len()), &mut []);
                 let val = Str::new(&s, &mut actor.alloc);
-                actor.insns.push(Insn::push { val });
+                gen_const(val, actor);
             }
 
             Expr::ByteArray(bytes) => {
@@ -362,7 +372,7 @@ impl ExprBox
                 actor.gc_check(ByteArray::alloc_size(bytes.len()), &mut []);
                 let ba = ByteArray::with_size(bytes.len(), &mut actor.alloc);
                 unsafe { ba.as_ba().get_slice_mut(0, bytes.len()).copy_from_slice(&bytes) };
-                actor.insns.push(Insn::push { val: ba });
+                gen_const(ba, actor);
                 actor.insns.push(Insn::ba_clone);
             }
 
@@ -394,10 +404,9 @@ impl ExprBox
 
             Expr::Member { base, field } => {
                 base.gen_code(fun, actor)?;
-                actor.gc_check(Str::alloc_size(field.len()), &mut []);
-                let field = Str::new(&field, &mut actor.alloc);
+                let name = actor.intern_name(field);
                 actor.insns.push(Insn::get_field {
-                    field,
+                    name,
                     class_id: Default::default(),
                     slot_idx: Default::default(),
                 });
@@ -476,8 +485,7 @@ impl ExprBox
                             arg.gen_code(fun, actor)?;
                         }
 
-                        actor.gc_check(Str::alloc_size(field.len()), &mut []);
-                        let name = Str::new(&field, &mut actor.alloc);
+                        let name = actor.intern_name(field);
                         actor.insns.push(Insn::call_method { name, argc });
                     }
 
@@ -570,11 +578,10 @@ fn gen_dict_expr(
 
         expr.gen_code(fun, actor)?;
 
-        actor.gc_check(Str::alloc_size(name.len()), &mut []);
-        let field_name = Str::new(&name, &mut actor.alloc);
+        let field_name = actor.intern_name(name);
 
         actor.insns.push(Insn::set_field {
-            field: field_name,
+            name: field_name,
             class_id: Default::default(),
             slot_idx: Default::default(),
         });
@@ -829,13 +836,10 @@ fn gen_assign(
                 rhs.gen_code(fun, actor)?;
             }
 
-            // Allocated after the operands: generating them can collect,
-            // and a name held across that would be left dangling
-            actor.gc_check(Str::alloc_size(field.len()), &mut []);
-            let field = Str::new(&field, &mut actor.alloc);
+            let name = actor.intern_name(field);
 
             actor.insns.push(Insn::set_field {
-                field,
+                name,
                 class_id: Default::default(),
                 slot_idx: Default::default(),
             });

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -323,6 +323,8 @@ impl ExprBox
             Expr::Nil => actor.insns.push(Insn::push { val: Value::NIL }),
             Expr::True => actor.insns.push(Insn::push { val: Value::TRUE }),
             Expr::False => actor.insns.push(Insn::push { val: Value::FALSE }),
+
+            // FIXME: for host calls, emit call_host directly, don't push a host function id
             Expr::HostFn(f) => actor.insns.push(Insn::push { val: Value::host_fn(*f) }),
 
             // Constants that don't fit in an immediate are boxed in the

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,11 +1,11 @@
 use std::mem::size_of;
-use crate::ast::*;
-use crate::lexer::ParseError;
-use crate::symbols::Decl;
-use crate::vm::Insn;
-use crate::value::Value;
 use crate::alloc::HEADER_SIZE;
+use crate::ast::*;
+use crate::insns::Insn;
+use crate::lexer::{ParseError, SrcPos};
 use crate::str::Str;
+use crate::symbols::Decl;
+use crate::value::Value;
 use crate::vm::Actor;
 
 /// Compiled function object
@@ -14,32 +14,121 @@ pub struct CompiledFun
 {
     pub entry_pc: usize,
     pub num_params: usize,
-    pub num_locals: usize,
+
+    /// Registers the frame occupies. Arguments come first, then locals,
+    /// then the temporaries an expression needs while it is evaluated
+    pub frame_size: usize,
 }
 
-/// Emit a push of a heap constant. The value moves into the actor's
-/// constant pool, which roots it, so nothing later in codegen has to
-/// keep it alive across an allocation
-fn gen_const(val: Value, actor: &mut Actor)
+/// Assigns registers within one function's frame.
+///
+/// Arguments occupy `r0..num_params`, locals the registers just above
+/// them, and temporaries everything above that. Temporaries are handed
+/// out and given back in stack order, so a caller notes the top before
+/// generating subexpressions and frees back to it once it has consumed
+/// their results.
+struct Regs
 {
-    let idx = actor.push_const(val);
-    actor.insns.push(Insn::push_const { idx });
+    /// First register a temporary can use
+    temp_base: u16,
+
+    /// Next free temporary
+    next: u16,
+
+    /// High water mark, which is the frame size the function needs
+    max: u16,
 }
 
-// Patch a jump instruction
-fn patch_jump(code: &mut Vec<Insn>, jmp_idx: usize, dst_idx: usize)
+impl Regs
 {
-    let jump_ofs = (dst_idx as i32) - (jmp_idx as i32) - 1;
+    /// Start a function, with the temporaries placed above its variables
+    fn new(fun: &Function) -> Self
+    {
+        let temp_base: u16 = (fun.params.len() + fun.num_locals)
+            .try_into()
+            .expect("function has too many arguments and locals");
 
-    match &mut code[jmp_idx] {
-        Insn::if_true { target_ofs } |
-        Insn::if_false { target_ofs } |
-        Insn::jump { target_ofs } => {
-            *target_ofs = jump_ofs;
-        }
-
-        _ => todo!()
+        // A frame always has room for r0: a call writes its return value
+        // there, and a constructor reads self from it
+        Self { temp_base, next: temp_base, max: std::cmp::max(temp_base, 1) }
     }
+
+    /// First free register, which `free_to` takes back down to
+    fn top(&self) -> u16
+    {
+        self.next
+    }
+
+    /// Give back every temporary handed out since `top` was taken
+    fn free_to(&mut self, top: u16)
+    {
+        debug_assert!(top >= self.temp_base);
+        self.next = top;
+    }
+
+    /// Reserve one register to hold an intermediate value
+    fn alloc(&mut self) -> u16
+    {
+        self.alloc_n(1)
+    }
+
+    /// Reserve a run of consecutive registers, as a call's arguments need
+    fn alloc_n(&mut self, n: u16) -> u16
+    {
+        let reg = self.next;
+        self.next = self.next.checked_add(n).expect("frame is too large");
+        self.max = std::cmp::max(self.max, self.next);
+        reg
+    }
+}
+
+/// Register an argument or local variable lives in
+fn decl_reg(decl: &Decl, fun: &Function) -> u16
+{
+    match *decl {
+        Decl::Arg { idx, .. } => idx as u16,
+        Decl::Local { idx, .. } => fun.params.len() as u16 + idx as u16,
+        _ => panic!("declaration does not live in a register")
+    }
+}
+
+/// Emit an instruction and return its index, for later patching
+fn emit(actor: &mut Actor, insn: Insn) -> usize
+{
+    actor.insns.push(insn);
+    actor.insns.len() - 1
+}
+
+/// Point a previously emitted jump at an instruction index. Displacements
+/// count instructions from the one after the jump
+fn patch_jump(actor: &mut Actor, jmp_idx: usize, dst_idx: usize)
+{
+    let disp = (dst_idx as i64) - (jmp_idx as i64) - 1;
+    let disp = disp.try_into().expect("jump is out of range");
+    actor.insns[jmp_idx] = actor.insns[jmp_idx].with_branch_disp(disp);
+}
+
+/// Load a value that needs no heap allocation. Immediates that fit the
+/// instruction go inline, the rest through the constant pool
+fn gen_value(actor: &mut Actor, dst: u16, val: Value)
+{
+    let raw = val.raw_bits();
+
+    // load_imm32 sign-extends, so a value round-trips only if its top
+    // bits are already the sign extension of the low 32
+    if (raw as i32 as i64 as u64) == raw {
+        emit(actor, Insn::load_imm32(dst, raw as i32));
+    } else {
+        let slot = actor.push_const(val);
+        emit(actor, Insn::load_const(dst, slot));
+    }
+}
+
+/// Load a heap constant, which always goes through the pool
+fn gen_const(actor: &mut Actor, dst: u16, val: Value)
+{
+    let slot = actor.push_const(val);
+    emit(actor, Insn::load_const(dst, slot));
 }
 
 impl Function
@@ -67,36 +156,26 @@ impl Function
         // Entry address of the compiled function
         let entry_pc = actor.insns.len();
 
-        //let start_idx = actor.insns.len();
+        let mut regs = Regs::new(self);
 
         // Compile the function body
-        self.body.gen_code(self, &mut vec![], &mut vec![], actor)?;
-
-        /*
-        let end_idx = actor.insns.len();
-        println!("# {}", self.name);
-        for i in start_idx..end_idx {
-            println!("{:?}", actor.insns[i]);
-        }
-        println!();
-        */
+        self.body.gen_code(self, &mut regs, &mut vec![], &mut vec![], actor)?;
 
         // If the body needs a final return
         if self.needs_final_return() {
-            // If this is a constructor, return the self argument
             if self.is_ctor() {
-                actor.insns.push(Insn::get_arg { idx: 0 });
+                // A constructor hands back the object it was called on,
+                // which is its first argument
+                actor.insns.push(Insn::ret(0));
             } else {
-                actor.insns.push(Insn::push { val: Value::NIL });
+                actor.insns.push(Insn::ret_nil());
             }
-
-            actor.insns.push(Insn::ret);
         }
 
         Ok(CompiledFun {
             entry_pc,
             num_params: self.params.len(),
-            num_locals: self.num_locals,
+            frame_size: regs.max as usize,
         })
     }
 }
@@ -106,6 +185,7 @@ impl StmtBox
     fn gen_code(
         &self,
         fun: &Function,
+        regs: &mut Regs,
         break_idxs: &mut Vec<usize>,
         cont_idxs: &mut Vec<usize>,
         actor: &mut Actor,
@@ -113,155 +193,157 @@ impl StmtBox
     {
         match self.stmt.as_ref() {
             Stmt::Expr(expr) => {
+                let top = regs.top();
+
                 match expr.expr.as_ref() {
-                    // For assignment expressions as statements,
-                    // avoid generating output that we would then need to pop
+                    // For assignment expressions as statements, the
+                    // assigned value itself is not needed
                     Expr::Binary { op: BinOp::Assign, lhs, rhs } => {
-                        gen_assign(lhs, rhs, fun, actor, false)?;
+                        gen_assign(lhs, rhs, fun, regs, actor, false)?;
                     }
 
                     _ => {
-                        expr.gen_code(fun, actor)?;
-                        actor.insns.push(Insn::pop);
+                        expr.gen_code(fun, regs, actor, None)?;
                     }
                 }
+
+                regs.free_to(top);
             }
 
             Stmt::Break => {
-                break_idxs.push(actor.insns.len());
-                actor.insns.push(Insn::jump { target_ofs: 0});
+                break_idxs.push(emit(actor, Insn::jmp(0)));
             }
 
             Stmt::Continue => {
-                cont_idxs.push(actor.insns.len());
-                actor.insns.push(Insn::jump { target_ofs: 0});
+                cont_idxs.push(emit(actor, Insn::jmp(0)));
             }
 
             Stmt::Return(expr) => {
-                expr.gen_code(fun, actor)?;
-                actor.insns.push(Insn::ret);
+                let top = regs.top();
+                let src = expr.gen_code(fun, regs, actor, None)?;
+                actor.insns.push(Insn::ret(src));
+                regs.free_to(top);
             }
 
             Stmt::Block(stmts) => {
-                // For each closure declaration
+                // Closures are created before the block runs, so that they
+                // can capture each other
                 if !fun.is_unit {
+                    // For each closure declaration
                     for stmt in stmts {
                         if let Stmt::Let { init_expr, decl, .. } = stmt.stmt.as_ref() {
                             if let Expr::Fun { fun_id, captured } = init_expr.expr.as_ref() {
-                                // Create the closure
-                                actor.insns.push(Insn::clos_new {
-                                    fun_id: *fun_id,
-                                    num_slots: captured.len() as u32,
-                                });
+                                let top = regs.top();
+                                let decl = decl.as_ref().unwrap();
 
+                                // Create the closure. The slots are filled
+                                // in by the Let below
+                                let clos = write_target(decl, fun, regs);
+                                actor.insns.push(Insn::clos_new(
+                                    clos,
+                                    usize::from(*fun_id) as u32,
+                                    captured.len().try_into().unwrap(),
+                                ));
                                 // Initialize the local variable for this closure
-                                gen_var_write(decl.as_ref().unwrap(), fun, &mut actor.insns);
+                                gen_var_write(decl, fun, regs, actor, clos);
+
+                                regs.free_to(top);
                             }
                         }
                     }
                 }
 
                 for stmt in stmts {
-                    stmt.gen_code(fun, break_idxs, cont_idxs, actor)?;
+                    stmt.gen_code(fun, regs, break_idxs, cont_idxs, actor)?;
                 }
             }
 
             Stmt::If { test_expr, then_stmt, else_stmt } => {
                 // Compile the test expression
-                test_expr.gen_code(fun, actor)?;
+                let top = regs.top();
+                let test = test_expr.gen_code(fun, regs, actor, None)?;
 
                 // If false, jump to else stmt
-                let if_idx = actor.insns.len();
-                actor.insns.push(Insn::if_false { target_ofs: 0 });
+                let if_idx = emit(actor, Insn::if_false(test, 0));
+                regs.free_to(top);
 
                 if else_stmt.is_some() {
-                    then_stmt.gen_code(fun, break_idxs, cont_idxs, actor)?;
-                    let jump_idx = actor.insns.len();
-                    actor.insns.push(Insn::jump { target_ofs: 0 });
+                    then_stmt.gen_code(fun, regs, break_idxs, cont_idxs, actor)?;
+                    let jump_idx = emit(actor, Insn::jmp(0));
 
                     // Patch the if_false to jump to the else clause
                     let dst_idx = actor.insns.len();
-                    patch_jump(&mut actor.insns, if_idx, dst_idx);
+                    patch_jump(actor, if_idx, dst_idx);
 
-                    else_stmt.as_ref().unwrap().gen_code(fun, break_idxs, cont_idxs, actor)?;
+                    else_stmt.as_ref().unwrap().gen_code(fun, regs, break_idxs, cont_idxs, actor)?;
 
                     // Patch the jump instruction to jump after the else clause
                     let dst_idx = actor.insns.len();
-                    patch_jump(&mut actor.insns, jump_idx, dst_idx);
+                    patch_jump(actor, jump_idx, dst_idx);
                 }
                 else
                 {
-                    then_stmt.gen_code(fun, break_idxs, cont_idxs, actor)?;
+                    then_stmt.gen_code(fun, regs, break_idxs, cont_idxs, actor)?;
 
-                    // Patch the if_false to jump to the else clause
-                    let jump_ofs = (actor.insns.len() as i32) - (if_idx as i32) - 1;
-                    if let Insn::if_false { target_ofs } = &mut actor.insns[if_idx] {
-                        *target_ofs = jump_ofs;
-                    }
+                    let dst_idx = actor.insns.len();
+                    patch_jump(actor, if_idx, dst_idx);
                 }
             }
 
             Stmt::For { init_stmt, test_expr, incr_expr, body_stmt } => {
                 // Generate code for the init statement
-                init_stmt.gen_code(
-                    fun,
-                    break_idxs,
-                    cont_idxs,
-                    actor,
-                )?;
+                init_stmt.gen_code(fun, regs, break_idxs, cont_idxs, actor)?;
 
                 let mut break_idxs = Vec::new();
                 let mut cont_idxs = Vec::new();
 
                 // Evaluate the test expression
                 let test_idx = actor.insns.len();
-                test_expr.gen_code(fun, actor)?;
+                let top = regs.top();
+                let test = test_expr.gen_code(fun, regs, actor, None)?;
 
                 // If the test fails, jump after the loop
-                break_idxs.push(actor.insns.len());
-                actor.insns.push(Insn::if_false { target_ofs: 0 });
+                break_idxs.push(emit(actor, Insn::if_false(test, 0)));
+                regs.free_to(top);
 
-                body_stmt.gen_code(
-                    fun,
-                    &mut break_idxs,
-                    &mut cont_idxs,
-                    actor,
-                )?;
+                body_stmt.gen_code(fun, regs, &mut break_idxs, &mut cont_idxs, actor)?;
 
                 // Continue will jump here
                 let cont_idx = actor.insns.len();
 
                 // Evaluate the increment expression
-                incr_expr.gen_code(fun, actor)?;
-                actor.insns.push(Insn::pop);
+                let top = regs.top();
+                incr_expr.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
 
                 // Jump back to the loop test
-                actor.insns.push(Insn::jump { target_ofs: 0 });
-                let jmp_idx = actor.insns.len() - 1;
-                patch_jump(&mut actor.insns, jmp_idx, test_idx);
+                let jmp_idx = emit(actor, Insn::jmp(0));
+                patch_jump(actor, jmp_idx, test_idx);
 
                 // Break will jump here
                 let break_idx = actor.insns.len();
 
                 // Patch continue jumps
                 for branch_idx in cont_idxs.iter() {
-                    patch_jump(&mut actor.insns, *branch_idx, cont_idx);
+                    patch_jump(actor, *branch_idx, cont_idx);
                 }
 
                 // Patch break jumps
                 for branch_idx in break_idxs.iter() {
-                    patch_jump(&mut actor.insns, *branch_idx, break_idx);
+                    patch_jump(actor, *branch_idx, break_idx);
                 }
             }
 
             Stmt::Assert { test_expr } => {
-                test_expr.gen_code(fun, actor)?;
+                let top = regs.top();
+                let test = test_expr.gen_code(fun, regs, actor, None)?;
+                let if_idx = emit(actor, Insn::if_true(test, 0));
+                regs.free_to(top);
 
-                let if_idx = actor.insns.len();
-                actor.insns.push(Insn::if_true { target_ofs: 0 });
-                actor.insns.push(Insn::panic { pos: self.pos });
+                gen_panic(actor, self.pos);
+
                 let dst_idx = actor.insns.len();
-                patch_jump(&mut actor.insns, if_idx, dst_idx);
+                patch_jump(actor, if_idx, dst_idx);
             }
 
             // Variable declaration
@@ -271,323 +353,431 @@ impl StmtBox
                     return Ok(())
                 }
 
+                let decl = decl.as_ref().unwrap();
+                let top = regs.top();
+
                 match init_expr.expr.as_ref() {
                     Expr::Fun { fun_id: _, captured } => {
-                        // Read the closure decl
-                        let decl = decl.as_ref().unwrap();
-                        gen_var_read(decl, fun, &mut actor.insns);
-
-                        // For each variable captured by the closure
-                        for (idx, decl) in captured.iter().enumerate() {
-                            actor.insns.push(Insn::dup);
-
-                            // Copy variables and cells captured by the closure
-                            match decl {
-                                Decl::Local { idx, mutable: true, .. } => {
-                                    actor.insns.push(Insn::get_local { idx: *idx });
-                                }
-                                _ => gen_var_read(decl, fun, &mut actor.insns)
-                            }
-                            actor.insns.push(Insn::clos_set { idx: idx as u32 });
-                        }
+                        // Read the closure decl. The closure itself was
+                        // created before the block, so this only fills in
+                        // what it captures
+                        let clos = gen_var_read(decl, fun, regs, actor, None);
+                        gen_captures(captured, clos, fun, regs, actor);
                     }
 
-                    _ => init_expr.gen_code(fun, actor)?
+                    _ => {
+                        // An escaping variable holds a cell, and the cell
+                        // is created below, so the value cannot be written
+                        // straight into the variable's own register
+                        let dst = if fun.escaping.contains(decl) {
+                            None
+                        } else {
+                            Some(write_target(decl, fun, regs))
+                        };
+
+                        let src = init_expr.gen_code(fun, regs, actor, dst)?;
+
+                        // If this is an escaping mutable variable
+                        if fun.escaping.contains(decl) {
+                            // Allocate a mutable closure cell for this variable
+                            let cell = decl_reg(decl, fun);
+                            actor.insns.push(Insn::cell_new(cell));
+                            actor.insns.push(Insn::cell_set(cell, src));
+                        } else {
+                            // Initialize the local variable
+                            gen_var_write(decl, fun, regs, actor, src);
+                        }
+                    }
                 }
 
-                // If this is an escaping mutable variable
-                if fun.escaping.contains(decl.as_ref().unwrap()) {
-                    let local_idx = match decl.unwrap() {
-                        Decl::Local { idx, .. } => idx,
-                        _ => panic!()
-                    };
-
-                    // Allocate a mutable closure cell for this variable
-                    actor.insns.push(Insn::cell_new);
-                    actor.insns.push(Insn::set_local { idx: local_idx });
-                }
-
-                // Initialize the local variable
-                gen_var_write(decl.as_ref().unwrap(), fun, &mut actor.insns);
+                regs.free_to(top);
             }
 
             Stmt::ClassDecl { .. } => {}
-
-            //_ => todo!("{:?}", self.stmt)
         }
 
         Ok(())
     }
 }
 
+/// Emit a panic carrying the source position it happened at. The fields
+/// are wider than any real source file needs, but a generated one could
+/// overflow them, so this saturates rather than letting the encoding
+/// assert fire
+fn gen_panic(actor: &mut Actor, pos: SrcPos)
+{
+    let file_id = std::cmp::min(pos.file_id(), u16::MAX as u32) as u16;
+    let line_no = std::cmp::min(pos.line_no(), (1 << 20) - 1);
+    let col_no = std::cmp::min(pos.col_no(), (1 << 20) - 1);
+    actor.insns.push(Insn::panic(file_id, line_no, col_no));
+}
+
 impl ExprBox
 {
+    /// Generate code for an expression and return the register holding
+    /// its value.
+    ///
+    /// `dst` is a hint: an expression that has to write somewhere writes
+    /// there, but one whose value already sits in a register hands that
+    /// register back untouched. Callers that need the value in a specific
+    /// register go through `gen_into`.
     fn gen_code(
         &self,
         fun: &Function,
+        regs: &mut Regs,
         actor: &mut Actor,
-    ) -> Result<(), ParseError>
+        dst: Option<u16>,
+    ) -> Result<u16, ParseError>
     {
-        match self.expr.as_ref() {
-            Expr::Nil => actor.insns.push(Insn::push { val: Value::NIL }),
-            Expr::True => actor.insns.push(Insn::push { val: Value::TRUE }),
-            Expr::False => actor.insns.push(Insn::push { val: Value::FALSE }),
+        // Register to write into, for the cases that produce a new value
+        macro_rules! out {
+            () => { match dst { Some(dst) => dst, None => regs.alloc() } }
+        }
 
-            // FIXME: for host calls, emit call_host directly, don't push a host function id
-            Expr::HostFn(f) => actor.insns.push(Insn::push { val: Value::host_fn(*f) }),
+        let reg = match self.expr.as_ref() {
+            Expr::Nil => { let d = out!(); gen_value(actor, d, Value::NIL); d }
+            Expr::True => { let d = out!(); gen_value(actor, d, Value::TRUE); d }
+            Expr::False => { let d = out!(); gen_value(actor, d, Value::FALSE); d }
+
+            Expr::HostFn(f) => {
+                let d = out!();
+                gen_value(actor, d, Value::host_fn(*f));
+                d
+            }
 
             // Constants that don't fit in an immediate are boxed in the
             // heap the code is compiled for, and held by the constant
             // pool, which is what the collector traces them from
             Expr::Int64(v) => {
+                let d = out!();
+
                 match Value::try_fixnum(*v) {
-                    Some(val) => actor.insns.push(Insn::push { val }),
+                    Some(val) => gen_value(actor, d, val),
                     None => {
                         actor.gc_check(HEADER_SIZE + size_of::<i64>(), &mut []);
                         let val = actor.alloc.heap_int64(*v);
-                        gen_const(val, actor);
+                        gen_const(actor, d, val);
                     }
                 }
+
+                d
             }
 
             Expr::Float64(v) => {
+                let d = out!();
+
                 match Value::try_flonum(*v) {
-                    Some(val) => actor.insns.push(Insn::push { val }),
+                    Some(val) => gen_value(actor, d, val),
                     None => {
                         actor.gc_check(HEADER_SIZE + size_of::<f64>(), &mut []);
                         let val = actor.alloc.heap_float64(*v);
-                        gen_const(val, actor);
+                        gen_const(actor, d, val);
                     }
                 }
+
+                d
             }
 
             Expr::String(s) => {
+                let d = out!();
                 actor.gc_check(Str::alloc_size(s.len()), &mut []);
                 let val = Str::new(&s, &mut actor.alloc);
-                gen_const(val, actor);
+                gen_const(actor, d, val);
+                d
             }
 
             Expr::ByteArray(bytes) => {
                 use crate::bytearray::ByteArray;
+                let d = out!();
                 actor.gc_check(ByteArray::alloc_size(bytes.len()), &mut []);
                 let ba = ByteArray::with_size(bytes.len(), &mut actor.alloc);
                 unsafe { ba.as_ba().get_slice_mut(0, bytes.len()).copy_from_slice(&bytes) };
-                gen_const(ba, actor);
-                actor.insns.push(Insn::ba_clone);
+                gen_const(actor, d, ba);
+                actor.insns.push(Insn::ba_clone(d, d));
+                d
             }
 
             Expr::Array { exprs } => {
-                return gen_arr_expr(
-                    exprs,
-                    fun,
-                    actor,
-                );
+                let d = out!();
+                actor.insns.push(Insn::arr_new(d, exprs.len() as u32));
+
+                for expr in exprs {
+                    let top = regs.top();
+                    let val = expr.gen_code(fun, regs, actor, None)?;
+                    actor.insns.push(Insn::arr_push(d, val));
+                    regs.free_to(top);
+                }
+
+                d
             }
 
             Expr::Dict { pairs } => {
-                return gen_dict_expr(
-                    pairs,
-                    fun,
-                    actor,
-                );
+                let d = out!();
+                actor.insns.push(Insn::dict_new(d));
+
+                // For each field
+                for (name, expr) in pairs {
+                    let top = regs.top();
+                    let val = expr.gen_code(fun, regs, actor, None)?;
+                    let cache = actor.new_prop_cache(name);
+                    actor.insns.push(Insn::set_field(d, val, cache));
+                    regs.free_to(top);
+                }
+
+                d
             }
 
-            Expr::Ref {decl, .. } => {
-                gen_var_read(decl, fun, &mut actor.insns);
+            Expr::Ref { decl, .. } => {
+                gen_var_read(decl, fun, regs, actor, dst)
             }
 
             Expr::Index { base, index } => {
-                base.gen_code(fun, actor)?;
-                index.gen_code(fun, actor)?;
-                actor.insns.push(Insn::get_index);
+                let top = regs.top();
+                let arr = base.gen_code(fun, regs, actor, None)?;
+                let idx = index.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
+
+                let d = out!();
+                actor.insns.push(Insn::get_index(d, arr, idx));
+                d
             }
 
             Expr::Member { base, field } => {
-                base.gen_code(fun, actor)?;
-                let name = actor.intern_name(field);
-                actor.insns.push(Insn::get_field {
-                    name,
-                    class_id: Default::default(),
-                    slot_idx: Default::default(),
-                });
+                let top = regs.top();
+                let obj = base.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
+
+                let d = out!();
+                let cache = actor.new_prop_cache(field);
+                actor.insns.push(Insn::get_field(d, obj, cache));
+                d
             }
 
             Expr::InstanceOf { val, class_id, .. } => {
-                val.gen_code(fun, actor)?;
-                actor.insns.push(Insn::instanceof { class_id: *class_id });
+                let top = regs.top();
+                let v = val.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
+
+                let d = out!();
+                actor.insns.push(Insn::instanceof(d, v, usize::from(*class_id) as u32));
+                d
             }
 
             Expr::Unary { op, child } => {
-                child.gen_code(fun, actor)?;
+                let top = regs.top();
+                let src = child.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
+
+                let d = out!();
 
                 match op {
-                    UnOp::Minus => {
-                        actor.insns.push(Insn::push { val: Value::fixnum(-1) });
-                        actor.insns.push(Insn::mul);
-                    }
+                    // Negation is a multiply, which keeps the numeric
+                    // tower in one place
+                    UnOp::Minus => actor.insns.push(Insn::mul_imm16(d, src, -1)),
 
                     // Logical negation
-                    UnOp::Not => {
-                        actor.insns.push(Insn::not);
-                    }
-
-                    //_ => todo!()
+                    UnOp::Not => actor.insns.push(Insn::not(d, src)),
                 }
-            },
+
+                d
+            }
 
             Expr::Binary { op, lhs, rhs } => {
-                gen_bin_op(op, lhs, rhs, fun, actor)?;
+                return gen_bin_op(op, lhs, rhs, fun, regs, actor, dst);
             }
 
             Expr::Ternary { test_expr, then_expr, else_expr } => {
-                // Evaluate the test expression
-                test_expr.gen_code(fun, actor)?;
-                let if_idx = actor.insns.len();
-                actor.insns.push(Insn::if_false { target_ofs: 0 });
+                // Both arms have to land in the same register
+                let d = out!();
+
+                let top = regs.top();
+                let test = test_expr.gen_code(fun, regs, actor, None)?;
+                let if_idx = emit(actor, Insn::if_false(test, 0));
+                regs.free_to(top);
 
                 // Evaluate the then expression
-                then_expr.gen_code(fun, actor)?;
-                let jump_idx = actor.insns.len();
-                actor.insns.push(Insn::jump { target_ofs: 0 });
+                gen_into(then_expr, fun, regs, actor, d)?;
+                let jump_idx = emit(actor, Insn::jmp(0));
 
                 // Patch the if_false to jump to the else clause
                 let dst_idx = actor.insns.len();
-                patch_jump(&mut actor.insns, if_idx, dst_idx);
+                patch_jump(actor, if_idx, dst_idx);
 
                 // Evaluate the else expression
-                else_expr.gen_code(fun, actor)?;
+                gen_into(else_expr, fun, regs, actor, d)?;
 
                 // Patch the jump over the else expression
                 let dst_idx = actor.insns.len();
-                patch_jump(&mut actor.insns, jump_idx, dst_idx);
+                patch_jump(actor, jump_idx, dst_idx);
+
+                d
             }
 
             Expr::Call { callee, args } => {
-                let argc = args.len().try_into().unwrap();
-
-                match callee.expr.as_ref() {
-                    // New class instance
-                    Expr::Ref { decl: Decl::Class { id }, .. } => {
-                        // Evaluate the arguments
-                        for arg in args {
-                            arg.gen_code(fun, actor)?;
-                        }
-
-                        actor.insns.push(Insn::new { class_id: *id, argc });
-                    }
-
-                    // Callee has form a.b
-                    Expr::Member { base, field } => {
-                        // Evaluate the self argument
-                        base.gen_code(fun, actor)?;
-
-                        for arg in args {
-                            arg.gen_code(fun, actor)?;
-                        }
-
-                        let name = actor.intern_name(field);
-                        actor.insns.push(Insn::call_method { name, argc });
-                    }
-
-                    // Call to a known function
-                    Expr::Ref { decl: Decl::Fun { id }, .. } => {
-                        for arg in args {
-                            arg.gen_code(fun, actor)?;
-                        }
-
-                        actor.insns.push(Insn::call_direct { fun_id: *id, argc });
-                    }
-
-                    // Plain regular call
-                    _ => {
-                        for arg in args {
-                            arg.gen_code(fun, actor)?;
-                        }
-
-                        callee.gen_code(fun, actor)?;
-                        actor.insns.push(Insn::call { argc });
-                    }
-                }
+                return gen_call(callee, args, fun, regs, actor);
             }
 
             // Function expression
             Expr::Fun { fun_id, captured } => {
+                let d = out!();
+
                 // If this is not a closure
                 if captured.len() == 0 {
-                    actor.insns.push(Insn::push { val: Value::fun(*fun_id) });
-                    return Ok(())
+                    gen_value(actor, d, Value::fun(*fun_id));
+                    return Ok(d);
                 }
 
-                actor.insns.push(Insn::clos_new {
-                    fun_id: *fun_id,
-                    num_slots: captured.len() as u32,
-                });
-
-                // For each variable captured by the closure
-                for (idx, decl) in captured.iter().enumerate() {
-                    actor.insns.push(Insn::dup);
-
-                    // Copy variables and cells captured by the closure
-                    match decl {
-                        Decl::Local { idx, mutable: true, .. } => {
-                            actor.insns.push(Insn::get_local { idx: *idx });
-                        }
-                        _ => gen_var_read(decl, fun, &mut actor.insns)
-                    }
-                    actor.insns.push(Insn::clos_set { idx: idx as u32 });
-                }
+                actor.insns.push(Insn::clos_new(
+                    d,
+                    usize::from(*fun_id) as u32,
+                    captured.len().try_into().unwrap(),
+                ));
+                gen_captures(captured, d, fun, regs, actor);
+                d
             }
 
             _ => todo!("{:?}", self)
+        };
+
+        Ok(reg)
+    }
+}
+
+/// Generate an expression into a specific register
+fn gen_into(
+    expr: &ExprBox,
+    fun: &Function,
+    regs: &mut Regs,
+    actor: &mut Actor,
+    dst: u16,
+) -> Result<(), ParseError>
+{
+    let top = regs.top();
+    let src = expr.gen_code(fun, regs, actor, Some(dst))?;
+
+    if src != dst {
+        actor.insns.push(Insn::mov(dst, src));
+    }
+
+    regs.free_to(top);
+    Ok(())
+}
+
+/// Fill in the slots of a closure that has already been created
+fn gen_captures(
+    captured: &Vec<Decl>,
+    clos: u16,
+    fun: &Function,
+    regs: &mut Regs,
+    actor: &mut Actor,
+)
+{
+    // For each variable captured by the closure
+    for (idx, decl) in captured.iter().enumerate() {
+        let top = regs.top();
+
+        // Copy variables and cells captured by the closure.
+        // A mutable local is captured by its cell, not by its value
+        let src = match decl {
+            Decl::Local { idx, mutable: true, .. } => fun.params.len() as u16 + *idx as u16,
+            _ => gen_var_read(decl, fun, regs, actor, None)
+        };
+
+        actor.insns.push(Insn::clos_set(clos, src, idx.try_into().unwrap()));
+        regs.free_to(top);
+    }
+}
+
+/// Generate a call, whose arguments have to land in consecutive registers
+/// starting at the callee's frame base. The return value comes back in
+/// that same register
+fn gen_call(
+    callee: &ExprBox,
+    args: &Vec<ExprBox>,
+    fun: &Function,
+    regs: &mut Regs,
+    actor: &mut Actor,
+) -> Result<u16, ParseError>
+{
+    let n_args: u16 = args.len().try_into().expect("too many call arguments");
+
+    // A method call and a constructor both pass self as argument zero. A
+    // dynamic call parks the callee just above the arguments, where the
+    // callee's own frame overwrites it once the call is under way
+    let (argc, extra_slot) = match callee.expr.as_ref() {
+        Expr::Member { .. } => (n_args + 1, 0),
+        Expr::Ref { decl: Decl::Class { .. }, .. } => (n_args + 1, 0),
+        Expr::Ref { decl: Decl::Fun { .. }, .. } => (n_args, 0),
+        Expr::HostFn(_) => (n_args, 0),
+        _ => (n_args, 1),
+    };
+
+    let argc: u8 = argc.try_into().expect("too many call arguments");
+
+    // A call with no arguments still needs the register its return value
+    // comes back in
+    let top = regs.top();
+    let start = regs.alloc_n(std::cmp::max(argc as u16 + extra_slot, 1));
+
+    match callee.expr.as_ref() {
+        // New class instance. The object is created into the callee's
+        // frame base and handed to the constructor as self
+        Expr::Ref { decl: Decl::Class { id }, .. } => {
+            // Evaluate the arguments
+            for (i, arg) in args.iter().enumerate() {
+                gen_into(arg, fun, regs, actor, start + 1 + i as u16)?;
+            }
+
+            actor.insns.push(Insn::new(usize::from(*id) as u32, start, argc));
         }
 
-        Ok(())
-    }
-}
+        // Callee has form a.b
+        Expr::Member { base, field } => {
+            // Evaluate the self argument
+            gen_into(base, fun, regs, actor, start)?;
 
-// Generate code for an array literal expression
-fn gen_arr_expr(
-    exprs: &Vec<ExprBox>,
-    fun: &Function,
-    actor: &mut Actor,
-) -> Result<(), ParseError>
-{
-    actor.insns.push(Insn::arr_new { capacity: exprs.len() as u32 });
+            for (i, arg) in args.iter().enumerate() {
+                gen_into(arg, fun, regs, actor, start + 1 + i as u16)?;
+            }
 
-    for expr in exprs {
-        actor.insns.push(Insn::dup);
-        expr.gen_code(fun, actor)?;
-        actor.insns.push(Insn::arr_push);
-    }
+            let cache = actor.new_call_cache(field);
+            actor.insns.push(Insn::call_method(start, argc, cache));
+        }
 
-    Ok(())
-}
+        // Call to a known function
+        Expr::Ref { decl: Decl::Fun { id }, .. } => {
+            for (i, arg) in args.iter().enumerate() {
+                gen_into(arg, fun, regs, actor, start + i as u16)?;
+            }
 
-// Generate code for a dictionary literal expression
-fn gen_dict_expr(
-    pairs: &Vec<(String, ExprBox)>,
-    fun: &Function,
-    actor: &mut Actor,
-) -> Result<(), ParseError>
-{
-    actor.insns.push(Insn::dict_new);
+            actor.insns.push(Insn::call_direct(usize::from(*id) as u32, start, argc));
+        }
 
-    // For each field
-    for (name, expr) in pairs {
-        actor.insns.push(Insn::dup);
+        // Call to a host function, which the VM provides
+        Expr::HostFn(host_fn) => {
+            for (i, arg) in args.iter().enumerate() {
+                gen_into(arg, fun, regs, actor, start + i as u16)?;
+            }
 
-        expr.gen_code(fun, actor)?;
+            actor.insns.push(Insn::call_host(*host_fn as u16, start, argc));
+        }
 
-        let field_name = actor.intern_name(name);
+        // Plain regular call
+        _ => {
+            for (i, arg) in args.iter().enumerate() {
+                gen_into(arg, fun, regs, actor, start + i as u16)?;
+            }
 
-        actor.insns.push(Insn::set_field {
-            name: field_name,
-            class_id: Default::default(),
-            slot_idx: Default::default(),
-        });
+            gen_into(callee, fun, regs, actor, start + argc as u16)?;
+
+            let cache = actor.new_call_cache("");
+            actor.insns.push(Insn::call_opnd(start, argc, cache));
+        }
     }
 
-    Ok(())
+    // The return value comes back in the callee's frame base
+    regs.free_to(top);
+    Ok(regs.alloc())
 }
 
 fn gen_bin_op(
@@ -595,210 +785,239 @@ fn gen_bin_op(
     lhs: &ExprBox,
     rhs: &ExprBox,
     fun: &Function,
+    regs: &mut Regs,
     actor: &mut Actor,
-) -> Result<(), ParseError>
+    dst: Option<u16>,
+) -> Result<u16, ParseError>
 {
     use BinOp::*;
 
     // Assignments are different from other kinds of expressions
     // because we don't evaluate the lhs the same way
     if *op == Assign {
-        gen_assign(lhs, rhs, fun, actor, true)?;
-        return Ok(());
+        return gen_assign(lhs, rhs, fun, regs, actor, true);
     }
 
-    // Logical AND (a && b)
-    if *op == And {
-        // If a is false, the result is false
-        lhs.gen_code(fun, actor)?;
-        let if0_idx = actor.insns.len();
-        actor.insns.push(Insn::if_false { target_ofs: 0 });
+    // Logical AND (a && b), logical OR (a || b). Both operands have to be
+    // booleans, so the short-circuit value is the one that got us there
+    if *op == And || *op == Or {
+        let d = match dst { Some(dst) => dst, None => regs.alloc() };
+        let short = if *op == And { Value::FALSE } else { Value::TRUE };
+        let long = if *op == And { Value::TRUE } else { Value::FALSE };
 
-        // If b is false, the result is false
-        rhs.gen_code(fun, actor)?;
-        let if1_idx = actor.insns.len();
-        actor.insns.push(Insn::if_false { target_ofs: 0 });
+        // If a short-circuits, it decides the result
+        let top = regs.top();
+        let a = lhs.gen_code(fun, regs, actor, None)?;
+        let if0_idx = emit(actor, if *op == And { Insn::if_false(a, 0) } else { Insn::if_true(a, 0) });
+        regs.free_to(top);
 
-        // Both subexpressions are true
-        actor.insns.push(Insn::push { val: Value::TRUE });
-        let jmp_idx = actor.insns.len();
-        actor.insns.push(Insn::jump { target_ofs: 0 });
+        // If b short-circuits, it decides the result
+        let b = rhs.gen_code(fun, regs, actor, None)?;
+        let if1_idx = emit(actor, if *op == And { Insn::if_false(b, 0) } else { Insn::if_true(b, 0) });
+        regs.free_to(top);
 
-        // If false, short-circuit here
+        // Neither operand short-circuited
+        gen_value(actor, d, long);
+        let jmp_idx = emit(actor, Insn::jmp(0));
+
+        // Short-circuit lands here
         let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, if0_idx, dst_idx);
-        let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, if1_idx, dst_idx);
-        actor.insns.push(Insn::push { val: Value::FALSE });
+        patch_jump(actor, if0_idx, dst_idx);
+        patch_jump(actor, if1_idx, dst_idx);
+        gen_value(actor, d, short);
 
         // Done label
         let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, jmp_idx, dst_idx);
+        patch_jump(actor, jmp_idx, dst_idx);
 
-        return Ok(());
+        return Ok(d);
     }
 
-    // Logical OR (a || b)
-    if *op == Or {
-
-        // If a is true, the result is true
-        lhs.gen_code(fun, actor)?;
-        let if0_idx = actor.insns.len();
-        actor.insns.push(Insn::if_true { target_ofs: 0 });
-
-        // If b is true, the result is true
-        rhs.gen_code(fun, actor)?;
-        let if1_idx = actor.insns.len();
-        actor.insns.push(Insn::if_true { target_ofs: 0 });
-
-        // Both subexpressions are false
-        actor.insns.push(Insn::push { val: Value::FALSE });
-        let jmp_idx = actor.insns.len();
-        actor.insns.push(Insn::jump { target_ofs: 0 });
-
-        // If true, short-circuit here
-        let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, if0_idx, dst_idx);
-        let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, if1_idx, dst_idx);
-        actor.insns.push(Insn::push { val: Value::TRUE });
-
-        // Done label
-        let dst_idx = actor.insns.len();
-        patch_jump(&mut actor.insns, jmp_idx, dst_idx);
-
-        return Ok(());
-    }
-
-    // If the rhs is a constant integer value that fits in an immediate
+    // If the rhs is a constant integer that fits an immediate operand
     if let Expr::Int64(int_val) = rhs.expr.as_ref() {
-        // The negation below has to fit as well, so keep one bit of room
-        let fits = Value::fits_fixnum(*int_val) && Value::fits_fixnum(-*int_val);
+        let imm: Result<i16, _> = (*int_val).try_into();
 
-        match op {
-            Add if fits => {
-                lhs.gen_code(fun, actor)?;
-                actor.insns.push(Insn::add_i64 { val: *int_val });
-                return Ok(())
+        if let Ok(imm) = imm {
+            let build = match op {
+                Add => Some(Insn::add_imm16 as fn(u16, u16, i16) -> Insn),
+                Sub => Some(Insn::sub_imm16 as fn(u16, u16, i16) -> Insn),
+                Mul => Some(Insn::mul_imm16 as fn(u16, u16, i16) -> Insn),
+                _ => None,
+            };
+
+            if let Some(build) = build {
+                let top = regs.top();
+                let a = lhs.gen_code(fun, regs, actor, None)?;
+                regs.free_to(top);
+
+                let d = match dst { Some(dst) => dst, None => regs.alloc() };
+                actor.insns.push(build(d, a, imm));
+                return Ok(d);
             }
-
-            Sub if fits => {
-                lhs.gen_code(fun, actor)?;
-                actor.insns.push(Insn::add_i64 { val: -int_val });
-                return Ok(())
-            }
-
-            _ => {}
         }
     }
 
-    lhs.gen_code(fun, actor)?;
-    rhs.gen_code(fun, actor)?;
+    let top = regs.top();
+    let a = lhs.gen_code(fun, regs, actor, None)?;
+    let b = rhs.gen_code(fun, regs, actor, None)?;
+    regs.free_to(top);
 
-    match op {
-        BitAnd => actor.insns.push(Insn::bit_and),
-        BitOr => actor.insns.push(Insn::bit_or),
-        BitXor => actor.insns.push(Insn::bit_xor),
-        LShift => actor.insns.push(Insn::lshift),
-        RShift => actor.insns.push(Insn::rshift),
+    let d = match dst { Some(dst) => dst, None => regs.alloc() };
 
-        Add => actor.insns.push(Insn::add),
-        Sub => actor.insns.push(Insn::sub),
-        Mul => actor.insns.push(Insn::mul),
-        Div => actor.insns.push(Insn::div),
-        IntDiv => actor.insns.push(Insn::div_int),
-        Mod => actor.insns.push(Insn::modulo),
+    // A comparison has no value-producing form, so it is materialized
+    // from the branch that tests it
+    let cmp = match op {
+        Eq => Some(Insn::jeq as fn(u16, u16, i32) -> Insn),
+        Ne => Some(Insn::jne as fn(u16, u16, i32) -> Insn),
+        Lt => Some(Insn::jlt as fn(u16, u16, i32) -> Insn),
+        Le => Some(Insn::jle as fn(u16, u16, i32) -> Insn),
+        Gt => Some(Insn::jgt as fn(u16, u16, i32) -> Insn),
+        Ge => Some(Insn::jge as fn(u16, u16, i32) -> Insn),
+        _ => None,
+    };
 
-        Eq => actor.insns.push(Insn::eq),
-        Ne => actor.insns.push(Insn::ne),
-        Lt => actor.insns.push(Insn::lt),
-        Le => actor.insns.push(Insn::le),
-        Gt => actor.insns.push(Insn::gt),
-        Ge => actor.insns.push(Insn::ge),
+    if let Some(cmp) = cmp {
+        let jcc_idx = emit(actor, cmp(a, b, 0));
+        gen_value(actor, d, Value::FALSE);
+        let jmp_idx = emit(actor, Insn::jmp(0));
 
-        _ => todo!("{:?}", op),
+        let dst_idx = actor.insns.len();
+        patch_jump(actor, jcc_idx, dst_idx);
+        gen_value(actor, d, Value::TRUE);
+
+        let dst_idx = actor.insns.len();
+        patch_jump(actor, jmp_idx, dst_idx);
+
+        return Ok(d);
     }
 
-    Ok(())
+    let insn = match op {
+        BitAnd => Insn::bit_and(d, a, b),
+        BitOr => Insn::bit_or(d, a, b),
+        BitXor => Insn::bit_xor(d, a, b),
+        LShift => Insn::lshift(d, a, b),
+        RShift => Insn::rshift(d, a, b),
+
+        Add => Insn::add(d, a, b),
+        Sub => Insn::sub(d, a, b),
+        Mul => Insn::mul(d, a, b),
+        Div => Insn::div(d, a, b),
+        IntDiv => Insn::div_int(d, a, b),
+        Mod => Insn::modulo(d, a, b),
+
+        _ => todo!("{:?}", op),
+    };
+
+    actor.insns.push(insn);
+    Ok(d)
 }
 
-/// Generate a write to a variable
-/// Assumes the value to be written is on top of the stack
+/// Register a variable can be written into directly, if it has one. A
+/// global, a captured variable or an escaping local goes through an
+/// instruction instead, so those get a temporary
+fn write_target(decl: &Decl, fun: &Function, regs: &mut Regs) -> u16
+{
+    match decl {
+        Decl::Local { .. } | Decl::Arg { .. } if !fun.escaping.contains(decl) => {
+            decl_reg(decl, fun)
+        }
+        _ => regs.alloc()
+    }
+}
+
+/// Generate a write of a value held in `src` to a variable
 fn gen_var_write(
     decl: &Decl,
     fun: &Function,
-    code: &mut Vec<Insn>,
+    regs: &mut Regs,
+    actor: &mut Actor,
+    src: u16,
 )
 {
     match *decl {
         Decl::Global { idx, .. } => {
-            code.push(Insn::set_global { idx });
+            actor.insns.push(Insn::set_global(src, idx));
         }
 
-        Decl::Local { idx, .. } => {
-            // If this is an escaping mutable variable
-            if fun.escaping.contains(decl) {
-                code.push(Insn::get_local { idx });
-                code.push(Insn::cell_set);
+        Decl::Local { .. } | Decl::Arg { .. } => {
+            let reg = decl_reg(decl, fun);
 
-            } else {
-                code.push(Insn::set_local { idx });
+            // An escaping variable holds a cell, and the value goes in it
+            if fun.escaping.contains(decl) {
+                actor.insns.push(Insn::cell_set(reg, src));
+            } else if reg != src {
+                actor.insns.push(Insn::mov(reg, src));
             }
         }
 
         Decl::Captured { idx, mutable } => {
             assert!(mutable);
-            code.push(Insn::clos_get { idx });
-            code.push(Insn::cell_set);
+            let cell = regs.alloc();
+            actor.insns.push(Insn::clos_get(cell, idx.try_into().unwrap()));
+            actor.insns.push(Insn::cell_set(cell, src));
         }
 
         _ => todo!()
     }
 }
 
-/// Generate a write to a variable
-/// Pushes the value read on the stack
+/// Generate a read of a variable, returning the register its value ends
+/// up in. A local that is not escaping is already in a register, so it is
+/// handed back as it is
 fn gen_var_read(
     decl: &Decl,
     fun: &Function,
-    code: &mut Vec<Insn>,
-)
+    regs: &mut Regs,
+    actor: &mut Actor,
+    dst: Option<u16>,
+) -> u16
 {
+    macro_rules! out {
+        () => { match dst { Some(dst) => dst, None => regs.alloc() } }
+    }
+
     match *decl {
         Decl::Fun { id } => {
-            code.push(Insn::push { val: Value::fun(id) });
+            let d = out!();
+            gen_value(actor, d, Value::fun(id));
+            d
         }
 
         Decl::Class { id } => {
-            code.push(Insn::push { val: Value::class(id) });
+            let d = out!();
+            gen_value(actor, d, Value::class(id));
+            d
         }
 
         Decl::Global { idx, .. } => {
-            code.push(Insn::get_global { idx });
+            let d = out!();
+            actor.insns.push(Insn::get_global(d, idx));
+            d
         }
 
-        Decl::Arg { idx, .. } => {
-            code.push(Insn::get_arg { idx });
-        }
+        Decl::Arg { .. } => decl_reg(decl, fun),
 
-        Decl::Local { idx, .. } => {
-            // If this is an escaping mutable variable
+        Decl::Local { .. } => {
+            let reg = decl_reg(decl, fun);
+
             if fun.escaping.contains(decl) {
-                code.push(Insn::get_local { idx });
-                code.push(Insn::cell_get);
-
+                let d = out!();
+                actor.insns.push(Insn::cell_get(d, reg));
+                d
             } else {
-                code.push(Insn::get_local { idx });
+                reg
             }
         }
 
         Decl::Captured { idx, mutable } => {
+            let d = out!();
+            actor.insns.push(Insn::clos_get(d, idx.try_into().unwrap()));
+
             if mutable {
-                code.push(Insn::clos_get { idx });
-                code.push(Insn::cell_get);
-            } else {
-                code.push(Insn::clos_get { idx });
+                actor.insns.push(Insn::cell_get(d, d));
             }
+
+            d
         }
     }
 }
@@ -807,61 +1026,63 @@ fn gen_assign(
     lhs: &ExprBox,
     rhs: &ExprBox,
     fun: &Function,
+    regs: &mut Regs,
     actor: &mut Actor,
     need_value: bool,
-) -> Result<(), ParseError>
+) -> Result<u16, ParseError>
 {
-    //dbg!(lhs);
-    //dbg!(rhs);
-
     match lhs.expr.as_ref() {
         Expr::Ref { decl, .. } => {
-            rhs.gen_code(fun, actor)?;
-
-            // If the output value is needed
-            if need_value {
-                actor.insns.push(Insn::dup);
-            }
-
-            gen_var_write(decl, fun, &mut actor.insns);
+            // Writing straight into the variable's own register is what
+            // keeps a plain assignment down to the value's own code
+            let target = write_target(decl, fun, regs);
+            let src = rhs.gen_code(fun, regs, actor, Some(target))?;
+            gen_var_write(decl, fun, regs, actor, src);
+            Ok(src)
         }
 
         Expr::Member { base, field } => {
-            if need_value {
-                rhs.gen_code(fun, actor)?;
-                base.gen_code(fun, actor)?;
-                actor.insns.push(Insn::getn { idx: 1 });
-            } else {
-                base.gen_code(fun, actor)?;
-                rhs.gen_code(fun, actor)?;
+            // The assigned value is the result of the expression, so it
+            // is allocated before the operands and outlives them
+            let d = if need_value { Some(regs.alloc()) } else { None };
+
+            let top = regs.top();
+            let obj = base.gen_code(fun, regs, actor, None)?;
+            let src = rhs.gen_code(fun, regs, actor, d)?;
+
+            let cache = actor.new_prop_cache(field);
+            actor.insns.push(Insn::set_field(obj, src, cache));
+
+            if let Some(d) = d {
+                if d != src {
+                    actor.insns.push(Insn::mov(d, src));
+                }
             }
 
-            let name = actor.intern_name(field);
-
-            actor.insns.push(Insn::set_field {
-                name,
-                class_id: Default::default(),
-                slot_idx: Default::default(),
-            });
+            regs.free_to(top);
+            Ok(d.unwrap_or(src))
         }
 
         Expr::Index { base, index } => {
-            if need_value {
-                rhs.gen_code(fun, actor)?;
-                base.gen_code(fun, actor)?;
-                index.gen_code(fun, actor)?;
-                actor.insns.push(Insn::getn { idx: 2 });
-                actor.insns.push(Insn::set_index);
-            } else {
-                base.gen_code(fun, actor)?;
-                index.gen_code(fun, actor)?;
-                rhs.gen_code(fun, actor)?;
-                actor.insns.push(Insn::set_index);
+            let d = if need_value { Some(regs.alloc()) } else { None };
+
+            let top = regs.top();
+            let arr = base.gen_code(fun, regs, actor, None)?;
+            let idx = index.gen_code(fun, regs, actor, None)?;
+            let src = rhs.gen_code(fun, regs, actor, d)?;
+
+            actor.insns.push(Insn::set_index(arr, idx, src));
+
+            if let Some(d) = d {
+                if d != src {
+                    actor.insns.push(Insn::mov(d, src));
+                }
             }
+
+            regs.free_to(top);
+            Ok(d.unwrap_or(src))
         }
 
         _ => todo!()
     }
-
-    Ok(())
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -48,15 +48,202 @@ impl HostFn
     }
 }
 
+/// Pick the `FnPtr` variant for an arity. The table states the arity as
+/// a number, and the compiler checks it against the signature of the
+/// function it is paired with
+macro_rules! host_fn_ptr {
+    (0, $f:path) => { FnPtr::Fn0($f) };
+    (1, $f:path) => { FnPtr::Fn1($f) };
+    (2, $f:path) => { FnPtr::Fn2($f) };
+    (3, $f:path) => { FnPtr::Fn3($f) };
+    (4, $f:path) => { FnPtr::Fn4($f) };
+    (5, $f:path) => { FnPtr::Fn5($f) };
+    (8, $f:path) => { FnPtr::Fn8($f) };
+}
+
+/// Declare the table of host functions, in two groups. An entry names
+/// the Rust function that implements it, along with its arity.
+///
+/// Plush code knows a global by that same name. A method's name carries
+/// a type prefix, and several of them answer to the same bare name, so
+/// each method gives the name it is called by.
+///
+/// Generating the id enum, the table and the name lookup from one list
+/// is what keeps them in step: an id is always a valid index, and only
+/// the globals are reachable by name.
+macro_rules! def_host_fns {
+    (
+        globals { $($g_id:ident($g_argc:tt),)* }
+        methods { $($m_name:ident: $m_id:ident($m_argc:tt),)* }
+    ) => {
+        pub const NUM_HOST_FNS: usize =
+            0 $(+ { let _ = stringify!($g_id); 1 })*
+              $(+ { let _ = stringify!($m_name); 1 })*;
+
+        // Ids are stored in u16 instruction operands
+        const _: () = assert!(NUM_HOST_FNS <= u16::MAX as usize);
+
+        /// Identifies a host function by its position in `HOST_FNS`.
+        /// Narrow enough to sit in an instruction operand.
+        #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+        #[allow(non_camel_case_types)]
+        #[repr(u16)]
+        pub enum HostFnId
+        {
+            $($g_id,)*
+            $($m_id,)*
+        }
+
+        /// Every host function the VM provides, in `HostFnId` order.
+        /// The table is immutable and shared by every actor, so looking
+        /// one up costs an indexed load and no locking.
+        pub static HOST_FNS: [HostFn; NUM_HOST_FNS] = [
+            $(HostFn { name: stringify!($g_id), f: host_fn_ptr!($g_argc, $g_id) },)*
+            $(HostFn { name: stringify!($m_name), f: host_fn_ptr!($m_argc, $m_id) },)*
+        ];
+
+        impl HostFnId
+        {
+            /// Look up a host function that Plush code can name directly.
+            /// Methods are deliberately not reachable this way: they are
+            /// found by the type they are defined on instead
+            pub fn from_name(name: &str) -> Option<HostFnId>
+            {
+                match name {
+                    $(stringify!($g_id) => Some(HostFnId::$g_id),)*
+                    _ => None
+                }
+            }
+        }
+    };
+}
+
+impl HostFnId
+{
+    /// Get the host function this id refers to
+    pub fn get(self) -> &'static HostFn
+    {
+        &HOST_FNS[self as usize]
+    }
+}
+
+use crate::array::*;
+use crate::audio::*;
+use crate::bytearray::*;
+use crate::runtime::*;
+use crate::window::*;
+
+def_host_fns! {
+    // Functions Plush code names directly
+    globals {
+        time_current_ms(0),
+        cmd_num_args(0),
+        cmd_get_arg(1),
+        cmd_get_arg_or(2),
+        print(1),
+        println(1),
+        readln(0),
+        read_file(1),
+        read_file_utf8(1),
+        write_file(2),
+        make_dir(1),
+        vm_shrink_heap(1),
+        vm_gc_collect(0),
+        actor_id(0),
+        actor_parent(0),
+        actor_sleep(1),
+        actor_spawn(1),
+        actor_join(1),
+        actor_send(2),
+        actor_recv(0),
+        actor_poll(0),
+        window_create(4),
+        window_draw_frame(2),
+        audio_open_output(2),
+        audio_write_samples(2),
+        audio_open_input(2),
+        audio_read_samples(4),
+        exit(1),
+    }
+
+    // Methods on primitive types, found through `runtime::get_method`
+    methods {
+        to_s: true_to_s(1),
+        to_s: false_to_s(1),
+        to_s: nil_to_s(1),
+
+        abs: int64_abs(1),
+        min: int64_min(2),
+        max: int64_max(2),
+        to_f: int64_to_f(1),
+        to_s: int64_to_s(1),
+        to_hex: int64_to_hex(2),
+
+        abs: float64_abs(1),
+        ceil: float64_ceil(1),
+        floor: float64_floor(1),
+        trunc: float64_trunc(1),
+        sin: float64_sin(1),
+        cos: float64_cos(1),
+        tan: float64_tan(1),
+        atan: float64_atan(1),
+        sqrt: float64_sqrt(1),
+        min: float64_min(2),
+        max: float64_max(2),
+        clip: float64_clip(3),
+        pow: float64_pow(2),
+        exp: float64_exp(1),
+        ln: float64_ln(1),
+        to_f: float64_to_f(1),
+        to_s: float64_to_s(1),
+        format_decimals: float64_format_decimals(2),
+
+        from_codepoint: string_from_codepoint(2),
+        byte_at: string_byte_at(2),
+        char_at: string_char_at(2),
+        parse_int: string_parse_int(2),
+        parse_float: string_parse_float(1),
+        trim: string_trim(1),
+        upper: string_upper(1),
+        lower: string_lower(1),
+        split: string_split(2),
+        to_s: string_to_s(1),
+
+        with_size: array_with_size(3),
+        push: array_push(2),
+        pop: array_pop(1),
+        remove: array_remove(2),
+        insert: array_insert(3),
+        append: array_append(2),
+        resize: array_resize(3),
+
+        with_size: ba_with_size(2),
+        load_u32: ba_load_u32(2),
+        store_u32: ba_store_u32(3),
+        load_u16: ba_load_u16(2),
+        store_u16: ba_store_u16(3),
+        load_f32: ba_load_f32(2),
+        store_f32: ba_store_f32(3),
+        get_u32: ba_get_u32(2),
+        set_u32: ba_set_u32(3),
+        get_f32: ba_get_f32(2),
+        set_f32: ba_set_f32(3),
+        num_u32: ba_num_u32(1),
+        memcpy: ba_memcpy(5),
+        resize: ba_resize(2),
+        zero_fill: ba_zero_fill(1),
+        fill_u32: ba_fill_u32(4),
+        blit_bgra32: ba_blit_bgra32(8),
+
+        has: dict_has(2),
+    }
+}
+
 /// Get a host constant by name
 /// Returns an AST expression node for the constant,
 /// because we want host constants to be resolved early
 pub fn get_host_const(name: &str, fun: &Function, prog: &Program) -> Expr
 {
-    use FnPtr::*;
-    use crate::window::*;
-    use crate::audio::*;
-
     // This constant is only true inside the main unit
     if name == "MAIN_UNIT" {
         if fun.id == prog.main_fn {
@@ -66,77 +253,10 @@ pub fn get_host_const(name: &str, fun: &Function, prog: &Program) -> Expr
         }
     }
 
-    static TIME_CURRENT_MS: HostFn = HostFn { name: "time_current_ms", f: Fn0(time_current_ms) };
-    static CMD_NUM_ARGS: HostFn = HostFn { name: "cmd_num_args", f: Fn0(cmd_num_args) };
-    static CMD_GET_ARG: HostFn = HostFn { name: "cmd_get_arg", f: Fn1(cmd_get_arg) };
-    static CMD_GET_ARG_OR: HostFn = HostFn { name: "cmd_get_arg_or", f: Fn2(cmd_get_arg_or) };
-    static PRINT: HostFn = HostFn { name: "print", f: Fn1(print) };
-    static PRINTLN: HostFn = HostFn { name: "println", f: Fn1(println) };
-    static READLN: HostFn = HostFn { name: "readln", f: Fn0(readln) };
-    static READ_FILE: HostFn = HostFn { name: "read_file", f: Fn1(read_file) };
-    static READ_FILE_UTF8: HostFn = HostFn { name: "read_file_utf8", f: Fn1(read_file_utf8) };
-    static WRITE_FILE: HostFn = HostFn { name: "write_file", f: Fn2(write_file) };
-    static MAKE_DIR: HostFn = HostFn { name: "make_dir", f: Fn1(make_dir) };
-    static VM_SHRINK_HEAP: HostFn = HostFn { name: "vm_shrink_heap", f: Fn1(vm_shrink_heap) };
-    static VM_GC_COLLECT: HostFn = HostFn { name: "vm_gc_collect", f: Fn0(vm_gc_collect) };
-    static ACTOR_ID: HostFn = HostFn { name: "actor_id", f: Fn0(actor_id) };
-    static ACTOR_PARENT: HostFn = HostFn { name: "actor_parent", f: Fn0(actor_parent) };
-    static ACTOR_SLEEP: HostFn = HostFn { name: "actor_sleep", f: Fn1(actor_sleep) };
-    static ACTOR_SPAWN: HostFn = HostFn { name: "actor_spawn", f: Fn1(actor_spawn) };
-    static ACTOR_JOIN: HostFn = HostFn { name: "actor_join", f: Fn1(actor_join) };
-    static ACTOR_SEND: HostFn = HostFn { name: "actor_send", f: Fn2(actor_send) };
-    static ACTOR_RECV: HostFn = HostFn { name: "actor_recv", f: Fn0(actor_recv) };
-    static ACTOR_POLL: HostFn = HostFn { name: "actor_poll", f: Fn0(actor_poll) };
-    static WINDOW_CREATE: HostFn = HostFn { name: "window_create", f: Fn4(window_create) };
-    static WINDOW_DRAW_FRAME: HostFn = HostFn { name: "window_draw_frame", f: Fn2(window_draw_frame) };
-    static AUDIO_OPEN_OUTPUT: HostFn = HostFn { name: "audio_open_output", f: Fn2(audio_open_output) };
-    static AUDIO_WRITE_SAMPLES: HostFn = HostFn { name: "audio_write_samples", f: Fn2(audio_write_samples) };
-    static AUDIO_OPEN_INPUT: HostFn = HostFn { name: "audio_open_input", f: Fn2(audio_open_input) };
-    static AUDIO_READ_SAMPLES: HostFn = HostFn { name: "audio_read_samples", f: Fn4(audio_read_samples) };
-    static EXIT: HostFn = HostFn { name: "exit", f: Fn1(exit) };
-
-    let fn_ref = match name
-    {
-        "time_current_ms" => &TIME_CURRENT_MS,
-
-        "cmd_num_args" => &CMD_NUM_ARGS,
-        "cmd_get_arg" => &CMD_GET_ARG,
-        "cmd_get_arg_or" => &CMD_GET_ARG_OR,
-
-        "print" => &PRINT,
-        "println" => &PRINTLN,
-        "readln" => &READLN,
-        "read_file" => &READ_FILE,
-        "read_file_utf8" => &READ_FILE_UTF8,
-        "write_file" => &WRITE_FILE,
-        "make_dir" => &MAKE_DIR,
-
-        "vm_shrink_heap" => &VM_SHRINK_HEAP,
-        "vm_gc_collect" => &VM_GC_COLLECT,
-        "actor_id" => &ACTOR_ID,
-        "actor_parent" => &ACTOR_PARENT,
-        "actor_sleep" => &ACTOR_SLEEP,
-        "actor_spawn" => &ACTOR_SPAWN,
-        "actor_join" => &ACTOR_JOIN,
-        "actor_send" => &ACTOR_SEND,
-        "actor_recv" => &ACTOR_RECV,
-        "actor_poll" => &ACTOR_POLL,
-
-        "window_create" => &WINDOW_CREATE,
-        "window_draw_frame" => &WINDOW_DRAW_FRAME,
-
-        "audio_open_output" => &AUDIO_OPEN_OUTPUT,
-        "audio_write_samples" => &AUDIO_WRITE_SAMPLES,
-
-        "audio_open_input" => &AUDIO_OPEN_INPUT,
-        "audio_read_samples" => &AUDIO_READ_SAMPLES,
-
-        "exit" => &EXIT,
-
-        _ => panic!("unknown host constant `{name}`")
-    };
-
-    Expr::HostFn(fn_ref)
+    match HostFnId::from_name(name) {
+        Some(host_fn) => Expr::HostFn(host_fn.get()),
+        None => panic!("unknown host constant `{name}`")
+    }
 }
 
 /// Get the current time stamp in milliseconds
@@ -414,6 +534,26 @@ mod tests
         assert!(is_safe_path("foo.txt"));
         assert!(is_safe_path("data.csv"));
         assert!(is_safe_path("docs/language.md"));
+    }
+
+    #[test]
+    fn host_fn_ids()
+    {
+        use crate::host::HostFnId;
+
+        // The id enum and the table are generated from one list, so an
+        // id has to land on the entry it was declared with
+        assert_eq!(HostFnId::print.get().name, "print");
+        assert_eq!(HostFnId::ba_blit_bgra32.get().name, "blit_bgra32");
+        assert_eq!(HostFnId::float64_clip.get().num_params(), 3);
+
+        assert_eq!(HostFnId::from_name("println"), Some(HostFnId::println));
+        assert_eq!(HostFnId::from_name("nope"), None);
+
+        // Methods are not reachable as globals, even though they sit in
+        // the same table
+        assert_eq!(HostFnId::from_name("to_s"), None);
+        assert_eq!(HostFnId::from_name("int64_abs"), None);
     }
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -254,7 +254,7 @@ pub fn get_host_const(name: &str, fun: &Function, prog: &Program) -> Expr
     }
 
     match HostFnId::from_name(name) {
-        Some(host_fn) => Expr::HostFn(host_fn.get()),
+        Some(host_fn) => Expr::HostFn(host_fn),
         None => panic!("unknown host constant `{name}`")
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -85,11 +85,14 @@ macro_rules! def_host_fns {
 
         /// Identifies a host function by its position in `HOST_FNS`.
         /// Narrow enough to sit in an instruction operand.
-        #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+        #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
         #[allow(non_camel_case_types)]
         #[repr(u16)]
         pub enum HostFnId
         {
+            // The first entry stands in for "not resolved yet", which is
+            // what a call cache holds until its site has run
+            #[default]
             $($g_id,)*
             $($m_id,)*
         }
@@ -120,6 +123,13 @@ macro_rules! def_host_fns {
 
 impl HostFnId
 {
+    /// Recover an id from its index, as an instruction operand holds it
+    pub fn from_index(idx: u16) -> HostFnId
+    {
+        assert!((idx as usize) < NUM_HOST_FNS);
+        unsafe { std::mem::transmute(idx) }
+    }
+
     /// Get the host function this id refers to
     pub fn get(self) -> &'static HostFn
     {

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -353,6 +353,9 @@ macro_rules! def_opcodes {
 //   - The callee's frame base is caller_bp + start_reg
 //   - The return value is written to the callee's frame base, which is
 //     start_reg in the caller. Calls therefore need no destination operand
+//   - argc counts every register the call occupies from start_reg on.
+//     For a method call, self is the first of those, so it lands in the
+//     callee's r0 and is counted in argc
 //   - Future tail calls can just mutate the frame in-place
 // - Field and method names are NameIds, indices into an interned name
 //   table that lives outside the heap. Instructions hold no heap pointers,
@@ -480,6 +483,11 @@ def_opcodes! {
     // class it was last looked up on, live in the CallCache entry
     call_method { start_reg: reg, argc: u8, cache: u24 },
 
+    // Call a host method, cached on the object type tag.
+    // This is used for primitive types such as Int64, Float64 and String.
+    // The method name can also be recovered from the host function for deopt.
+    call_method_host { start_reg: reg, argc: u8, type_tag: u8, host_fn: u16 },
+
     // Creating a class instance runs a constructor, so it is a call
     new { class_id: u24, start_reg: reg, argc: u8 },
     new_known_ctor { start_reg: reg, argc: u8, cache: u24 },
@@ -488,7 +496,7 @@ def_opcodes! {
     ret { src: reg },
 
     // Return nil, as functions with no explicit return value do
-    ret_nil { },
+    ret_nil {},
 
     // Return a sign-extended immediate as the raw bits of a value.
     // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
@@ -605,7 +613,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 58);
+        assert_eq!(NUM_OPCODES, 59);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -109,42 +109,33 @@ def_opcodes! {
     store_u32 { num_opnds = 3 },
     store_u64 { num_opnds = 3 },
 
-    // 32-bit bitwise operations
-    //not_u32,
-    lshift_u32 { num_opnds = 3, num_outs = 1 },
-    rshift_u32 { num_opnds = 3, num_outs = 1 },
-    rshift_i32 { num_opnds = 3, num_outs = 1 },
-    and_u32 { num_opnds = 3, num_outs = 1 },
-    or_u32 { num_opnds = 3, num_outs = 1 },
-    xor_u32 { num_opnds = 3, num_outs = 1 },
+    // bitwise operations
+    //not,
+    lshift { num_opnds = 3, num_outs = 1 },
+    rshift { num_opnds = 3, num_outs = 1 },
+    and { num_opnds = 3, num_outs = 1 },
+    or { num_opnds = 3, num_outs = 1 },
+    xor { num_opnds = 3, num_outs = 1 },
 
     // op | dst_reg | reg0 | reg1
-    add_i32 { num_opnds = 3, num_outs = 1 },
-    sub_i32 { num_opnds = 3, num_outs = 1 },
-    mul_i32 { num_opnds = 3, num_outs = 1 },
-    div_i32 { num_opnds = 3, num_outs = 1 },
-    mod_i32 { num_opnds = 3, num_outs = 1 },
-    div_u32 { num_opnds = 3, num_outs = 1 },
-    mod_u32 { num_opnds = 3, num_outs = 1 },
+    add { num_opnds = 3, num_outs = 1 },
+    sub { num_opnds = 3, num_outs = 1 },
+    mul { num_opnds = 3, num_outs = 1 },
+    div { num_opnds = 3, num_outs = 1 },
+    modulo { num_opnds = 3, num_outs = 1 },
 
     // op | dst_reg:u16 | reg0:u16 | imm:i16
-    add_i32_imm { num_opnds = 3, num_outs = 1 },
-    sub_i32_imm { num_opnds = 3, num_outs = 1 },
-    mul_i32_imm { num_opnds = 3, num_outs = 1 },
-    div_i32_imm { num_opnds = 3, num_outs = 1 },
-    mod_i32_imm { num_opnds = 3, num_outs = 1 },
+    add_imm16 { num_opnds = 3, num_outs = 1 },
+    sub_imm16 { num_opnds = 3, num_outs = 1 },
+    mul_imm16 { num_opnds = 3, num_outs = 1 },
 
     // jxx | r0: u16 | r1: u16 | offset: i16
-    jeq_i32 { num_opnds = 3 },
-    jne_i32 { num_opnds = 3 },
-    jlt_i32 { num_opnds = 3 },
-    jle_i32 { num_opnds = 3 },
-    jgt_i32 { num_opnds = 3 },
-    jge_i32 { num_opnds = 3 },
-    //jlt_u32 { num_opnds = 3 },
-    //jle_u32 { num_opnds = 3 },
-    //jgt_u32 { num_opnds = 3 },
-    //jge_u32 { num_opnds = 3 },
+    jeq { num_opnds = 3 },
+    jne { num_opnds = 3 },
+    jlt { num_opnds = 3 },
+    jle { num_opnds = 3 },
+    jgt { num_opnds = 3 },
+    jge { num_opnds = 3 },
 
     // Unconditional jump
     // jmp | offset: i32
@@ -155,9 +146,6 @@ def_opcodes! {
 
     // call_host | host_fn_id: u16 | start_reg: u16 | num_args: u8
     call_host { num_opnds = 3 },
-
-    // TODO: we need to be able to call function pointers for doom
-    // call_ptr {}
 
     // Return the value in a register
     // ret | src_reg: u16

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -384,18 +384,6 @@ def_opcodes! {
     // Load a constant from a constant slot into a register
     load_const { dst: out_reg, slot: u32 },
 
-    // Note: we might want to be able to use a constant slot for the base?
-    load_u8 { dst: out_reg, base: reg, offset: u16 },
-    load_u16 { dst: out_reg, base: reg, offset: u16 },
-    load_u32 { dst: out_reg, base: reg, offset: u16 },
-    load_u64 { dst: out_reg, base: reg, offset: u16 },
-
-    // Store is encoded the same way as load for simplicity
-    store_u8 { src: reg, base: reg, offset: u16 },
-    store_u16 { src: reg, base: reg, offset: u16 },
-    store_u32 { src: reg, base: reg, offset: u16 },
-    store_u64 { src: reg, base: reg, offset: u16 },
-
     // Global variable access.
     get_global { dst: out_reg, idx: u32 },
     set_global { src: reg, idx: u32 },
@@ -617,7 +605,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 66);
+        assert_eq!(NUM_OPCODES, 58);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.
@@ -784,7 +772,6 @@ mod tests
         assert_eq!(Opcode::add.num_outs(), 1);
         assert_eq!(Opcode::jlt.num_opnds(), 3);
         assert_eq!(Opcode::jlt.num_outs(), 0);
-        assert_eq!(Opcode::store_u64.num_outs(), 0);
         assert_eq!(Opcode::ret_nil.num_opnds(), 0);
     }
 

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -406,6 +406,7 @@ def_opcodes! {
     bit_and { dst: out_reg, a: reg, b: reg },
     bit_or { dst: out_reg, a: reg, b: reg },
     bit_xor { dst: out_reg, a: reg, b: reg },
+    bit_not { dst: out_reg, src: reg },
 
     add { dst: out_reg, a: reg, b: reg },
     sub { dst: out_reg, a: reg, b: reg },
@@ -419,7 +420,7 @@ def_opcodes! {
     sub_imm16 { dst: out_reg, a: reg, imm: i16 },
     mul_imm16 { dst: out_reg, a: reg, imm: i16 },
 
-    // Logical and bitwise negation
+    // Logical negation of a boolean
     not { dst: out_reg, src: reg },
 
     // Closure operations.
@@ -616,7 +617,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 65);
+        assert_eq!(NUM_OPCODES, 66);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 use std::fmt;
 use std::mem::transmute;
+use crate::host::HostFnId;
 
 // Instructions are one 64-bit word. The opcode occupies the low 8 bits.
 // Operands are packed from bit 8 upwards, except the last one, which is
@@ -483,10 +484,14 @@ def_opcodes! {
     // class it was last looked up on, live in the CallCache entry
     call_method { start_reg: reg, argc: u8, cache: u24 },
 
-    // Call a host method, cached on the object type tag.
-    // This is used for primitive types such as Int64, Float64 and String.
-    // The method name can also be recovered from the host function for deopt.
-    call_method_host { start_reg: reg, argc: u8, type_tag: u8, host_fn: u16 },
+    // Call a host method, guarded on the type tag of the value in
+    // start_reg. This is used for primitive types such as Int64, Float64
+    // and String. The guard is an immediate, so a miss costs no loads.
+    // The host function itself lives in the CallCache entry, which leaves
+    // room for the cache index: this site deoptimizes back into
+    // call_method, and the two forms take the same operands so that the
+    // switch is a write of the opcode byte
+    call_method_host { start_reg: reg, argc: u8, type_tag: u8, cache: u24 },
 
     // Creating a class instance runs a constructor, so it is a call
     new { class_id: u24, start_reg: reg, argc: u8 },
@@ -540,6 +545,10 @@ pub struct CallCache
     pub fun_id: u32,
     pub entry_pc: u32,
     pub num_locals: u16,
+
+    // Host function a call_method_host site resolved to. That site guards
+    // on the type tag in the instruction, so this is only read on a hit
+    pub host_fn: HostFnId,
 }
 
 /// Interpreter instruction
@@ -741,6 +750,16 @@ mod tests
         // A top-aligned u24 sitting above a u8
         assert_eq!(call_opnd::decode(Insn::call_opnd(0, 0, (1 << 24) - 1)).argc, 0);
         assert_eq!(call_opnd::decode(Insn::call_opnd(0, u8::MAX, 0)).cache, 0);
+
+        // call_method_host fills the word exactly, and deoptimizes into
+        // call_method, so the operands the two share have to line up
+        let host = Insn::call_method_host(1, 2, 3, 4);
+        assert_eq!(
+            call_method_host::decode(host),
+            call_method_host { start_reg: 1, argc: 2, type_tag: 3, cache: 4 }
+        );
+        let opnds = call_method::decode(Insn::call_method(1, 2, 4));
+        assert_eq!((opnds.start_reg, opnds.argc, opnds.cache), (1, 2, 4));
     }
 
     #[test]

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -420,10 +420,6 @@ def_opcodes! {
     cell_set { cell: reg, src: reg },
     cell_get { dst: out_reg, cell: reg },
 
-    // Creating a class instance runs a constructor, so it is a call
-    new { class_id: u24, start_reg: reg, argc: u8 },
-    //new_known_ctor { class_id: ClassId, argc: u8, num_slots: u16, ctor_pc: u32, fun_id: FunId, num_locals: u16 },
-
     // Check if instance of class
     instanceof { dst: out_reg, val: reg, class_id: u24 },
 
@@ -477,11 +473,15 @@ def_opcodes! {
     // We still use a cache entry because we can't fit all of the parameters
     // directly into one 64-bit instruction, but this instruction will
     // not deoptimize.
-    call_pc { start_reg: reg, num_locals: u16, cache: u24 },
+    call_pc { start_reg: reg, argc: u8, cache: u24 },
 
     // Call a method on the object in start_reg. The method name, and the
     // class it was last looked up on, live in the CallCache entry
     call_method { start_reg: reg, argc: u8, cache: u24 },
+
+    // Creating a class instance runs a constructor, so it is a call
+    new { class_id: u24, start_reg: reg, argc: u8 },
+    new_known_ctor { start_reg: reg, argc: u8, cache: u24 },
 
     // Return the value found in a register
     ret { src: reg },
@@ -604,7 +604,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 64);
+        assert_eq!(NUM_OPCODES, 65);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -1,25 +1,175 @@
 #![allow(dead_code)]
+#![allow(non_camel_case_types)]
+use std::fmt;
 use std::mem::transmute;
 
-// Helper macro to define instruction opcodes and associated metadata
+// Instructions are one 64-bit word. The opcode occupies the low 8 bits.
+// Operands are packed from bit 8 upwards, except the last one, which is
+// placed at the top of the word. Top-aligning the last operand makes its
+// extraction one shift instead of two, which is why signed immediates
+// should be declared last.
+const OPCODE_BITS: u32 = 8;
+
+/// Width in bits of each operand kind
+macro_rules! opnd_width {
+    (out_reg) => { 16 };
+    (reg) => { 16 };
+    (u1) => { 1 };
+    (u2) => { 2 };
+    (u3) => { 3 };
+    (u4) => { 4 };
+    (u5) => { 5 };
+    (u6) => { 6 };
+    (u8) => { 8 };
+    (u16) => { 16 };
+    (i16) => { 16 };
+    (i32) => { 32 };
+    (disp16) => { 16 };
+    (disp24) => { 24 };
+    (disp32) => { 32 };
+}
+
+/// Rust type an operand decodes to
+macro_rules! opnd_type {
+    (out_reg) => { u16 };
+    (reg) => { u16 };
+    (u1) => { u8 };
+    (u2) => { u8 };
+    (u3) => { u8 };
+    (u4) => { u8 };
+    (u5) => { u8 };
+    (u6) => { u8 };
+    (u8) => { u8 };
+    (u16) => { u16 };
+    (i16) => { i16 };
+    (i32) => { i32 };
+    (disp16) => { i16 };
+    (disp24) => { i32 };
+    (disp32) => { i32 };
+}
+
+/// Whether an operand is sign-extended when decoded
+macro_rules! opnd_signed {
+    (i16) => { true };
+    (i32) => { true };
+    (disp16) => { true };
+    (disp24) => { true };
+    (disp32) => { true };
+    ($other:ident) => { false };
+}
+
+/// 1 for operands the instruction writes to, 0 otherwise
+macro_rules! opnd_is_out {
+    (out_reg) => { 1 };
+    ($other:ident) => { 0 };
+}
+
+/// 1 for branch displacement operands, 0 otherwise
+macro_rules! opnd_is_disp {
+    (disp16) => { 1 };
+    (disp24) => { 1 };
+    (disp32) => { 1 };
+    ($other:ident) => { 0 };
+}
+
+// Keep the running result unless this operand is the branch displacement
+macro_rules! opnd_pick_disp {
+    (disp16, $prev:expr, $v:expr) => { Some($v as i32) };
+    (disp24, $prev:expr, $v:expr) => { Some($v as i32) };
+    (disp32, $prev:expr, $v:expr) => { Some($v as i32) };
+    ($other:ident, $prev:expr, $v:expr) => { $prev };
+}
+
+// Re-encoding an instruction: pass the operand through, or substitute a new
+// displacement if this is the branch displacement operand
+macro_rules! opnd_or_disp {
+    (disp16, $v:expr, $new:expr) => { $new as i16 };
+    (disp24, $v:expr, $new:expr) => { $new };
+    (disp32, $v:expr, $new:expr) => { $new };
+    ($other:ident, $v:expr, $new:expr) => { $v };
+}
+
+/// How an operand is printed by the disassembler
+macro_rules! opnd_fmt {
+    (out_reg, $f:expr, $v:expr) => { write!($f, "r{}", $v) };
+    (reg, $f:expr, $v:expr) => { write!($f, "r{}", $v) };
+    ($other:ident, $f:expr, $v:expr) => { write!($f, "{}", $v) };
+}
+
+macro_rules! decode_opnd {
+    ($insn:expr, $pos:expr, $kind:ident) => {
+        if opnd_signed!($kind) {
+            $insn.bits_i($pos, opnd_width!($kind)) as opnd_type!($kind)
+        } else {
+            $insn.bits_u($pos, opnd_width!($kind)) as opnd_type!($kind)
+        }
+    };
+}
+
+// Bind each operand to a local, walking the field list to accumulate bit
+// positions. The last operand is top-aligned, so it gets a fixed position.
+macro_rules! gen_decode {
+    // No operands left, nothing to bind
+    ($insn:ident, $pos:expr,) => {};
+
+    // Last operand: read it from the top of the word
+    ($insn:ident, $pos:expr, $fname:ident : $kind:ident,) => {
+        let $fname = decode_opnd!($insn, 64 - opnd_width!($kind), $kind);
+    };
+
+    // Any other operand: read it at the current position, then advance by its width
+    ($insn:ident, $pos:expr, $fname:ident : $kind:ident, $($rest:tt)+) => {
+        let $fname = decode_opnd!($insn, $pos, $kind);
+        gen_decode!($insn, $pos + opnd_width!($kind), $($rest)+);
+    };
+}
+
+macro_rules! gen_encode {
+    // No operands left, the word is complete
+    ($word:ident, $pos:expr,) => {};
+
+    // Last operand: write it to the top of the word
+    ($word:ident, $pos:expr, $fname:ident : $kind:ident,) => {
+        $word = $word.with_bits(64 - opnd_width!($kind), opnd_width!($kind), $fname as i64 as u64);
+    };
+
+    // Any other operand: write it at the current position, then advance by its width
+    ($word:ident, $pos:expr, $fname:ident : $kind:ident, $($rest:tt)+) => {
+        $word = $word.with_bits($pos, opnd_width!($kind), $fname as i64 as u64);
+        gen_encode!($word, $pos + opnd_width!($kind), $($rest)+);
+    };
+}
+
+// Check that an operand value is in range for the field it is encoded into
+macro_rules! check_opnd {
+    ($fname:ident, $kind:ident) => {
+        debug_assert!(
+            Insn::fits($fname as i64, opnd_width!($kind), opnd_signed!($kind)),
+            concat!("operand `", stringify!($fname), "` does not fit in ", stringify!($kind))
+        );
+    };
+}
+
+// Helper macro to define instruction opcodes and their operands
 macro_rules! def_opcodes {
     (
         $(
             $(#[doc = $doc:expr])*
-            $name:ident {
-                $(op = $val:expr,)?
-                num_opnds = $num_opnds:expr
-                $(, num_outs = $num_outs:expr)?
-                $(,)?
+            $name:ident $(= $val:literal)? {
+                $($fname:ident : $kind:ident),* $(,)?
             },
         )*
     ) => {
         pub const NUM_OPCODES: usize = 0 $( + { let _ = stringify!($name); 1 } )*;
 
+        // Opcodes are transmuted from a byte, so they have to cover it
+        // densely. The highest opcode value stays below 255, which leaves
+        // that value free for a future extension mechanism.
+        const _: () = assert!(NUM_OPCODES <= 255);
+
         /// Instruction opcodes
-        #[allow(non_camel_case_types)]
-        #[derive(PartialEq, Copy, Clone, Debug)]
-        #[repr(u16)]
+        #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+        #[repr(u8)]
         pub enum Opcode
         {
             $(
@@ -34,7 +184,7 @@ macro_rules! def_opcodes {
             {
                 match self {
                     $(
-                        Opcode::$name => $num_opnds,
+                        Opcode::$name => 0 $(+ { let _ = stringify!($fname); 1 })*,
                     )*
                 }
             }
@@ -43,7 +193,16 @@ macro_rules! def_opcodes {
             {
                 match self {
                     $(
-                        Opcode::$name => 0 $(+ $num_outs)?,
+                        Opcode::$name => 0 $(+ opnd_is_out!($kind))*,
+                    )*
+                }
+            }
+
+            pub fn name(self) -> &'static str
+            {
+                match self {
+                    $(
+                        Opcode::$name => stringify!($name),
                     )*
                 }
             }
@@ -55,6 +214,114 @@ macro_rules! def_opcodes {
                         stringify!($name) => Some(Opcode::$name),
                     )*
                     _ => None
+                }
+            }
+
+            /// Whether this instruction has a pc-relative branch displacement
+            pub fn is_branch(self) -> bool
+            {
+                match self {
+                    $(
+                        Opcode::$name => (0 $(+ opnd_is_disp!($kind))*) > 0,
+                    )*
+                }
+            }
+        }
+
+        // Decoded operands, one struct per opcode
+        $(
+            $(#[doc = $doc])*
+            #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+            pub struct $name
+            {
+                $(pub $fname: opnd_type!($kind),)*
+            }
+
+            const _: () = assert!(
+                OPCODE_BITS as usize $(+ opnd_width!($kind) as usize)* <= 64,
+                concat!("operands of `", stringify!($name), "` do not fit in one word")
+            );
+
+            impl $name
+            {
+                #[inline(always)]
+                pub fn decode(insn: Insn) -> Self
+                {
+                    debug_assert_eq!(insn.opcode(), Opcode::$name);
+                    gen_decode!(insn, OPCODE_BITS, $($fname: $kind,)*);
+                    Self { $($fname,)* }
+                }
+            }
+        )*
+
+        impl Insn
+        {
+            $(
+                $(#[doc = $doc])*
+                #[inline(always)]
+                pub fn $name($($fname: opnd_type!($kind)),*) -> Insn
+                {
+                    $(check_opnd!($fname, $kind);)*
+                    #[allow(unused_mut)]
+                    let mut word = Insn(Opcode::$name as u64);
+                    gen_encode!(word, OPCODE_BITS, $($fname: $kind,)*);
+                    word
+                }
+            )*
+
+            /// Get the branch displacement of a jump instruction, if it has one
+            #[allow(unused_mut, unused_assignments, unused_variables)]
+            pub fn branch_disp(self) -> Option<i32>
+            {
+                match self.opcode() {
+                    $(
+                        Opcode::$name => {
+                            let opnds = $name::decode(self);
+                            let mut disp: Option<i32> = None;
+                            $(disp = opnd_pick_disp!($kind, disp, opnds.$fname);)*
+                            disp
+                        }
+                    )*
+                }
+            }
+
+            /// Replace the branch displacement of a jump instruction.
+            /// Instructions with no displacement are returned unchanged.
+            #[allow(unused_variables)]
+            pub fn with_branch_disp(self, disp: i32) -> Insn
+            {
+                debug_assert!(self.opcode().is_branch(), "not a branch instruction");
+
+                match self.opcode() {
+                    $(
+                        Opcode::$name => {
+                            let opnds = $name::decode(self);
+                            Insn::$name($(opnd_or_disp!($kind, opnds.$fname, disp)),*)
+                        }
+                    )*
+                }
+            }
+        }
+
+        impl fmt::Display for Insn
+        {
+            #[allow(unused_mut, unused_assignments, unused_variables)]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
+            {
+                match self.opcode() {
+                    $(
+                        Opcode::$name => {
+                            let opnds = $name::decode(*self);
+                            write!(f, "{}", stringify!($name))?;
+                            let mut first = true;
+                            $(
+                                write!(f, "{}", if first { " " } else { ", " })?;
+                                first = false;
+                                opnd_fmt!($kind, f, opnds.$fname)?;
+                            )*
+                            Ok(())
+                        }
+                    )*
                 }
             }
         }
@@ -74,94 +341,84 @@ macro_rules! def_opcodes {
 def_opcodes! {
     // Halt execution and produce an error
     // Panic is zero so that jumping to uninitialized memory causes panic
-    panic { op = 0, num_opnds = 0 },
+    panic = 0 { },
 
     // Debugger breakpoint
-    breakpoint { num_opnds = 0 },
+    breakpoint { },
 
     // Can be used for code patching, or to disable breakpoints
-    nop { num_opnds = 0 },
+    nop { },
 
-    // Load a sign-extended immediate into a register as the raw bits of a value.
-    // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
-    // load_imm32 | dst_reg: u16 | imm: i32
-    load_imm32 { num_opnds = 2, num_outs = 1 },
+    // Load a sign-extended immediate into a register as the raw bits of a
+    // value. Covers nil, undef, booleans and fixnums in the +/- 2^29 range
+    load_imm32 { dst: out_reg, imm: i32 },
 
     // Copy a value from one register to another
-    // mov | dst_reg: u16 | src_reg: u16
-    mov { num_opnds = 2, num_outs = 1 },
+    mov { dst: out_reg, src: reg },
 
     // Load a constant from a constant slot into a register
-    // load_const | dst_reg: u16 | slot_idx: u16
-    load_const { num_opnds = 2, num_outs = 1 },
+    load_const { dst: out_reg, slot: u16 },
 
     // Note: we might want to be able to use a constant slot for the base?
-    // load_uxx | dst_reg: u16 | base_reg: u16 | offset: u16
-    load_u8 { num_opnds = 3, num_outs = 1 },
-    load_u16 { num_opnds = 3, num_outs = 1 },
-    load_u32 { num_opnds = 3, num_outs = 1 },
-    load_u64 { num_opnds = 3, num_outs = 1 },
+    load_u8 { dst: out_reg, base: reg, offset: u16 },
+    load_u16 { dst: out_reg, base: reg, offset: u16 },
+    load_u32 { dst: out_reg, base: reg, offset: u16 },
+    load_u64 { dst: out_reg, base: reg, offset: u16 },
 
     // Store is encoded the same way as load for simplicity
-    // store_uxx | src_reg: u16 | base_reg: u16 | offset: u16
-    store_u8 { num_opnds = 3 },
-    store_u16 { num_opnds = 3 },
-    store_u32 { num_opnds = 3 },
-    store_u64 { num_opnds = 3 },
+    store_u8 { src: reg, base: reg, offset: u16 },
+    store_u16 { src: reg, base: reg, offset: u16 },
+    store_u32 { src: reg, base: reg, offset: u16 },
+    store_u64 { src: reg, base: reg, offset: u16 },
 
     // bitwise operations
     //not,
-    lshift { num_opnds = 3, num_outs = 1 },
-    rshift { num_opnds = 3, num_outs = 1 },
-    and { num_opnds = 3, num_outs = 1 },
-    or { num_opnds = 3, num_outs = 1 },
-    xor { num_opnds = 3, num_outs = 1 },
+    lshift { dst: out_reg, a: reg, b: reg },
+    rshift { dst: out_reg, a: reg, b: reg },
+    and { dst: out_reg, a: reg, b: reg },
+    or { dst: out_reg, a: reg, b: reg },
+    xor { dst: out_reg, a: reg, b: reg },
 
-    // op | dst_reg | reg0 | reg1
-    add { num_opnds = 3, num_outs = 1 },
-    sub { num_opnds = 3, num_outs = 1 },
-    mul { num_opnds = 3, num_outs = 1 },
-    div { num_opnds = 3, num_outs = 1 },
-    modulo { num_opnds = 3, num_outs = 1 },
+    add { dst: out_reg, a: reg, b: reg },
+    sub { dst: out_reg, a: reg, b: reg },
+    mul { dst: out_reg, a: reg, b: reg },
+    div { dst: out_reg, a: reg, b: reg },
+    modulo { dst: out_reg, a: reg, b: reg },
 
-    // op | dst_reg:u16 | reg0:u16 | imm:i16
-    add_imm16 { num_opnds = 3, num_outs = 1 },
-    sub_imm16 { num_opnds = 3, num_outs = 1 },
-    mul_imm16 { num_opnds = 3, num_outs = 1 },
+    // Arithmetic ops with fixnum immediates
+    add_imm16 { dst: out_reg, a: reg, imm: i16 },
+    sub_imm16 { dst: out_reg, a: reg, imm: i16 },
+    mul_imm16 { dst: out_reg, a: reg, imm: i16 },
 
-    // jxx | r0: u16 | r1: u16 | offset: i16
-    jeq { num_opnds = 3 },
-    jne { num_opnds = 3 },
-    jlt { num_opnds = 3 },
-    jle { num_opnds = 3 },
-    jgt { num_opnds = 3 },
-    jge { num_opnds = 3 },
+    // The displacement takes the 24 bits left over by the two registers,
+    // which is more range than any function will need
+    jeq { a: reg, b: reg, disp: disp24 },
+    jne { a: reg, b: reg, disp: disp24 },
+    jlt { a: reg, b: reg, disp: disp24 },
+    jle { a: reg, b: reg, disp: disp24 },
+    jgt { a: reg, b: reg, disp: disp24 },
+    jge { a: reg, b: reg, disp: disp24 },
 
     // Unconditional jump
-    // jmp | offset: i32
-    jmp { num_opnds = 1 },
+    jmp { disp: disp32 },
 
-    // call | slot_idx: u16 | start_reg: u16 | num_args: u8
-    call { num_opnds = 3 },
+    call { fun: u16, start_reg: reg, num_args: u8 },
 
-    // call_host | host_fn_id: u16 | start_reg: u16 | num_args: u8
-    call_host { num_opnds = 3 },
+    call_host { host_fn: u16, start_reg: reg, num_args: u8 },
 
     // Return the value in a register
-    // ret | src_reg: u16
-    ret { num_opnds = 1 },
+    ret { src: reg },
 
     // Return nil, as functions with no explicit return value do
-    ret_nil { num_opnds = 0 },
+    ret_nil { },
 
     // Return a sign-extended immediate as the raw bits of a value.
     // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
-    // ret_imm32 | imm: i32
-    ret_imm32 { num_opnds = 1 },
+    ret_imm32 { imm: i32 },
 }
 
 /// Interpreter instruction
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Insn(u64);
 
 impl Insn
@@ -170,38 +427,8 @@ impl Insn
     pub fn opcode(&self) -> Opcode
     {
         let Insn(word) = self;
-        unsafe { transmute(*word as u16) }
-    }
-
-    /// Get a register operand
-    #[inline(always)]
-    pub fn reg(&self, idx: u16) -> u16
-    {
-        assert!(idx < 3);
-        let Insn(word) = self;
-        let shift = (idx + 1) * 16;
-        ((word >> shift) & 0xFFFF) as u16
-    }
-
-    /// Get an immediate i32 value at the end of the instruction word
-    #[inline(always)]
-    pub fn imm_i32(&self) -> i32
-    {
-        (self.0 >> 32) as i32
-    }
-
-    /// Get an immediate i16 value at the end of the instruction word
-    #[inline(always)]
-    pub fn imm_i16(&self) -> i16
-    {
-        (self.0 >> 48) as i16
-    }
-
-    /// Get an immediate u16 value at the end of the instruction word
-    #[inline(always)]
-    pub fn imm_u16(&self) -> u16
-    {
-        (self.0 >> 48) as u16
+        debug_assert!((*word as u8 as usize) < NUM_OPCODES);
+        unsafe { transmute(*word as u8) }
     }
 
     /// Get the full u64 instruction word
@@ -212,100 +439,198 @@ impl Insn
         *word
     }
 
-    pub fn encode_op(op: Opcode) -> Self
+    /// Extract an unsigned operand field
+    #[inline(always)]
+    const fn bits_u(&self, pos: u32, width: u32) -> u64
     {
-        Insn(op as u64)
+        (self.0 >> pos) & (u64::MAX >> (64 - width))
     }
 
-    /// Encode an instruction with a i32 operand
-    pub fn encode_i32(op: Opcode, imm: i32) -> Self
+    /// Extract a sign-extended operand field
+    #[inline(always)]
+    const fn bits_i(&self, pos: u32, width: u32) -> i64
     {
-        Insn(
-            (op as u64) |
-            (imm as u64) << 32
-        )
+        ((self.0 << (64 - pos - width)) as i64) >> (64 - width)
     }
 
-    /// Encode an instruction with a single register operand
-    pub fn encode_1reg(op: Opcode, r0: u16) -> Self
+    #[inline(always)]
+    const fn with_bits(self, pos: u32, width: u32, val: u64) -> Insn
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16
-        )
+        Insn(self.0 | ((val & (u64::MAX >> (64 - width))) << pos))
     }
 
-    /// Encode an instruction one register and one imm32 operand
-    pub fn encode_reg_i32(op: Opcode, r0: u16, imm: i32) -> Self
+    /// Whether a value is representable in a field of a given width
+    const fn fits(val: i64, width: u32, signed: bool) -> bool
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (imm as u64) << 32
-        )
+        if signed {
+            val >= -(1i64 << (width - 1)) && val < (1i64 << (width - 1))
+        } else {
+            val >= 0 && (val as u64) < (1u64 << width)
+        }
+    }
+}
+
+impl fmt::Debug for Insn
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
+    {
+        write!(f, "{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn opcode_count()
+    {
+        // Update this when adding opcodes, it is here to make the size of
+        // the instruction set visible as it grows
+        assert_eq!(NUM_OPCODES, 39);
+
+        // Opcodes are dense from zero, so this is the highest opcode value.
+        // It has to stay below 255 to leave room for a future extension.
+        assert!(NUM_OPCODES - 1 < 255);
+        assert_eq!(Opcode::ret_imm32 as usize, NUM_OPCODES - 1);
     }
 
-    /// Encode an instruction one register and one u16 operand
-    pub fn encode_reg_u16(op: Opcode, r0: u16, imm: u16) -> Self
+    #[test]
+    fn no_operands()
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (imm as u64) << 48
-        )
+        let insn = Insn::nop();
+        assert_eq!(insn.opcode(), Opcode::nop);
+        assert_eq!(insn.word_u64(), Opcode::nop as u64);
+        assert_eq!(Opcode::nop.num_opnds(), 0);
     }
 
-    /// Encode an instruction with 3 register operands
-    pub fn encode_3reg(op: Opcode, r0: u16, r1: u16, r2: u16) -> Self
+    #[test]
+    fn panic_is_zero()
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (r1 as u64) << 32 |
-            (r2 as u64) << 48
-        )
+        assert_eq!(Insn::panic().word_u64(), 0);
     }
 
-    /// Encode an instruction with 2 register operands
-    pub fn encode_2reg(op: Opcode, r0: u16, r1: u16) -> Self
+    #[test]
+    fn three_registers()
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (r1 as u64) << 32
-        )
+        let insn = Insn::add(1, 2, 3);
+        assert_eq!(insn.opcode(), Opcode::add);
+        assert_eq!(add::decode(insn), add { dst: 1, a: 2, b: 3 });
     }
 
-    /// Encode an instruction with 2 register operands and one i16 imm
-    pub fn encode_2reg_i16(op: Opcode, r0: u16, r1: u16, imm: i16) -> Self
+    #[test]
+    fn register_extremes()
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (r1 as u64) << 32 |
-            (imm as u64) << 48
-        )
+        let insn = Insn::add(u16::MAX, 0, u16::MAX);
+        assert_eq!(add::decode(insn), add { dst: u16::MAX, a: 0, b: u16::MAX });
     }
 
-    /// Encode an instruction with 2 register operands and one u16 imm
-    pub fn encode_2reg_u16(op: Opcode, r0: u16, r1: u16, imm: u16) -> Self
+    #[test]
+    fn signed_immediates_round_trip()
     {
-        Insn(
-            (op as u64) |
-            (r0 as u64) << 16 |
-            (r1 as u64) << 32 |
-            (imm as u64) << 48
-        )
+        for imm in [0, 1, -1, i16::MAX, i16::MIN] {
+            let insn = Insn::add_imm16(7, 8, imm);
+            assert_eq!(add_imm16::decode(insn), add_imm16 { dst: 7, a: 8, imm });
+        }
+
+        for imm in [0, 1, -1, i32::MAX, i32::MIN] {
+            assert_eq!(ret_imm32::decode(Insn::ret_imm32(imm)), ret_imm32 { imm });
+            assert_eq!(load_imm32::decode(Insn::load_imm32(3, imm)), load_imm32 { dst: 3, imm });
+        }
     }
 
-    // call | slot_idx: u16 | start_reg: u16 | num_args: u8
-    pub fn encode_call(op: Opcode, slot_idx: u16, start_reg: u16, num_args: u8) -> Self
+    #[test]
+    fn last_operand_is_top_aligned()
     {
-        Insn(
-            (op as u64) |
-            (slot_idx as u64) << 16 |
-            (start_reg as u64) << 32 |
-            (num_args as u64) << 48
-        )
+        // The branch displacement occupies the top 24 bits, the imm32 the top 32
+        assert_eq!((Insn::jlt(1, 2, -3).word_u64() as i64 >> 40) as i32, -3);
+        assert_eq!((Insn::load_imm32(1, -7).word_u64() >> 32) as i32, -7);
+    }
+
+    #[test]
+    fn branch_disp_range()
+    {
+        // A conditional jump uses the whole word, 24 bits of it for the
+        // displacement
+        for disp in [0, 1, -1, (1 << 23) - 1, -(1 << 23)] {
+            let insn = Insn::jlt(1, 2, disp);
+            assert_eq!(jlt::decode(insn), jlt { a: 1, b: 2, disp });
+        }
+    }
+
+    #[test]
+    fn branch_helpers()
+    {
+        assert!(Opcode::jlt.is_branch());
+        assert!(Opcode::jmp.is_branch());
+        assert!(!Opcode::add.is_branch());
+
+        assert_eq!(Insn::jlt(1, 2, -3).branch_disp(), Some(-3));
+        assert_eq!(Insn::jmp(1234).branch_disp(), Some(1234));
+        assert_eq!(Insn::add(1, 2, 3).branch_disp(), None);
+
+        // Patching a forward jump leaves the other operands alone
+        let patched = Insn::jlt(1, 2, 0).with_branch_disp(-3);
+        assert_eq!(patched, Insn::jlt(1, 2, -3));
+        assert_eq!(Insn::jmp(0).with_branch_disp(7), Insn::jmp(7));
+    }
+
+    #[test]
+    fn operands_do_not_overlap()
+    {
+        // Each operand set on its own must leave the others zero
+        assert_eq!(call::decode(Insn::call(u16::MAX, 0, 0)).start_reg, 0);
+        assert_eq!(call::decode(Insn::call(0, u16::MAX, 0)).fun, 0);
+        assert_eq!(call::decode(Insn::call(0, 0, u8::MAX)).fun, 0);
+        assert_eq!(call::decode(Insn::call(1, 2, 3)), call { fun: 1, start_reg: 2, num_args: 3 });
+    }
+
+    #[test]
+    fn narrow_operand_kinds()
+    {
+        // The narrow kinds are declared but unused by the table above, so
+        // exercise the width arithmetic directly
+        assert!(Insn::fits(1, 1, false));
+        assert!(!Insn::fits(2, 1, false));
+        assert!(Insn::fits(7, 3, false));
+        assert!(!Insn::fits(8, 3, false));
+        assert!(Insn::fits(15, 4, false));
+        assert!(!Insn::fits(16, 4, false));
+        assert!(Insn::fits(31, 5, false));
+        assert!(!Insn::fits(32, 5, false));
+        assert!(Insn::fits(63, 6, false));
+        assert!(!Insn::fits(64, 6, false));
+        assert!(Insn::fits(-8, 4, true));
+        assert!(!Insn::fits(-9, 4, true));
+    }
+
+    #[test]
+    fn opcode_metadata()
+    {
+        assert_eq!(Opcode::add.num_opnds(), 3);
+        assert_eq!(Opcode::add.num_outs(), 1);
+        assert_eq!(Opcode::jlt.num_opnds(), 3);
+        assert_eq!(Opcode::jlt.num_outs(), 0);
+        assert_eq!(Opcode::store_u64.num_outs(), 0);
+        assert_eq!(Opcode::ret_nil.num_opnds(), 0);
+    }
+
+    #[test]
+    fn opcode_names()
+    {
+        assert_eq!(Opcode::from_str("add"), Some(Opcode::add));
+        assert_eq!(Opcode::from_str("nope"), None);
+        assert_eq!(Opcode::add.name(), "add");
+    }
+
+    #[test]
+    fn disassembly()
+    {
+        assert_eq!(Insn::add(1, 2, 3).to_string(), "add r1, r2, r3");
+        assert_eq!(Insn::add_imm16(1, 2, -3).to_string(), "add_imm16 r1, r2, -3");
+        assert_eq!(Insn::jlt(4, 5, -6).to_string(), "jlt r4, r5, -6");
+        assert_eq!(Insn::ret_nil().to_string(), "ret_nil");
+        assert_eq!(Insn::call(7, 8, 9).to_string(), "call 7, r8, 9");
     }
 }

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -21,7 +21,10 @@ macro_rules! opnd_width {
     (u5) => { 5 };
     (u6) => { 6 };
     (u8) => { 8 };
+    (u12) => { 12 };
     (u16) => { 16 };
+    (u24) => { 24 };
+    (u32) => { 32 };
     (i16) => { 16 };
     (i32) => { 32 };
     (disp16) => { 16 };
@@ -40,7 +43,10 @@ macro_rules! opnd_type {
     (u5) => { u8 };
     (u6) => { u8 };
     (u8) => { u8 };
+    (u12) => { u16 };
     (u16) => { u16 };
+    (u24) => { u32 };
+    (u32) => { u32 };
     (i16) => { i16 };
     (i32) => { i32 };
     (disp16) => { i16 };
@@ -341,13 +347,13 @@ macro_rules! def_opcodes {
 def_opcodes! {
     // Halt execution and produce an error
     // Panic is zero so that jumping to uninitialized memory causes panic
-    panic = 0 { },
+    panic = 0 {},
 
     // Debugger breakpoint
-    breakpoint { },
+    breakpoint {},
 
     // Can be used for code patching, or to disable breakpoints
-    nop { },
+    nop {},
 
     // Load a sign-extended immediate into a register as the raw bits of a
     // value. Covers nil, undef, booleans and fixnums in the +/- 2^29 range
@@ -356,6 +362,7 @@ def_opcodes! {
     // Copy a value from one register to another
     mov { dst: out_reg, src: reg },
 
+    // FIXME: not fully clear how this will work yet. May want a 32-bit index?
     // Load a constant from a constant slot into a register
     load_const { dst: out_reg, slot: u16 },
 
@@ -371,24 +378,71 @@ def_opcodes! {
     store_u32 { src: reg, base: reg, offset: u16 },
     store_u64 { src: reg, base: reg, offset: u16 },
 
-    // bitwise operations
-    //not,
+    // Global variable access.
+    get_global { dst: out_reg, idx: u32 },
+    set_global { src: reg, idx: u32 },
+
+    // Bitwise operations
     lshift { dst: out_reg, a: reg, b: reg },
     rshift { dst: out_reg, a: reg, b: reg },
-    and { dst: out_reg, a: reg, b: reg },
-    or { dst: out_reg, a: reg, b: reg },
-    xor { dst: out_reg, a: reg, b: reg },
+    bit_and { dst: out_reg, a: reg, b: reg },
+    bit_or { dst: out_reg, a: reg, b: reg },
+    bit_xor { dst: out_reg, a: reg, b: reg },
 
     add { dst: out_reg, a: reg, b: reg },
     sub { dst: out_reg, a: reg, b: reg },
     mul { dst: out_reg, a: reg, b: reg },
     div { dst: out_reg, a: reg, b: reg },
+    div_int { dst: out_reg, a: reg, b: reg },
     modulo { dst: out_reg, a: reg, b: reg },
 
     // Arithmetic ops with fixnum immediates
     add_imm16 { dst: out_reg, a: reg, imm: i16 },
     sub_imm16 { dst: out_reg, a: reg, imm: i16 },
     mul_imm16 { dst: out_reg, a: reg, imm: i16 },
+
+    // Logical and bitwise negation
+    not { dst: out_reg, src: reg },
+
+    // Closure operations.
+    clos_new { dst: out_reg, fun_id: u24, num_slots: u12 },
+    clos_set { clos: reg, src: reg, idx: u12 },
+    clos_get { dst: out_reg, idx: u12 },
+
+    // Mutable cell operations. A new cell starts out holding nil.
+    cell_new { dst: out_reg },
+    cell_set { cell: reg, src: reg },
+    cell_get { dst: out_reg, cell: reg },
+
+    // Creating a class instance runs a constructor, so it is a call
+    new { class_id: u24, argc: u8 },
+    //new_known_ctor { class_id: ClassId, argc: u8, num_slots: u16, ctor_pc: u32, fun_id: FunId, num_locals: u16 },
+
+    // Check if instance of class
+    instanceof { dst: out_reg, val: reg, class_id: u16 },
+
+    // FIXME: figure out solution wrt string operands
+    // These name the field with a string pointer
+    //get_field { field: Value, class_id: ClassId, slot_idx: u32 },
+    //set_field { field: Value, class_id: ClassId, slot_idx: u32 },
+
+    // Get/set indexed element
+    get_index { dst: out_reg, arr: reg, idx: reg },
+    set_index { arr: reg, idx: reg, src: reg },
+
+    // Create a new dictionary
+    dict_new { dst: out_reg },
+
+    // Array operations
+    arr_new { dst: out_reg, capacity: u16 },
+    arr_push { arr: reg, val: reg },
+
+    // Clone a bytearray
+    ba_clone { dst: out_reg, src: reg },
+
+    // Jump if true/false
+    if_true { val: reg, disp: disp32 },
+    if_false { val: reg, disp: disp32 },
 
     // The displacement takes the 24 bits left over by the two registers,
     // which is more range than any function will need
@@ -402,11 +456,27 @@ def_opcodes! {
     // Unconditional jump
     jmp { disp: disp32 },
 
-    call { fun: u16, start_reg: reg, num_args: u8 },
+    // Call a function operand (dynamic call)
+    call { fun: reg,  start_reg: reg, argc: u8 },
 
+    // Call a host function provided by the VM
     call_host { host_fn: u16, start_reg: reg, num_args: u8 },
 
-    // Return the value in a register
+    // Call a known function by id
+    call_direct { fun: u24, start_reg: reg, num_args: u8 },
+
+    // Call an already compiled function with a known pc
+    // If we can't encode this call, we simply don't use this specialized instruction
+    call_pc { entry_pc: u24, fun_id: u16, num_locals: u8, argc: u8 },
+
+    // Call encodings still to be figured out. Brought over from the old VM
+    // as-is. The inline caches need somewhere to live, and the method calls
+    // name the method with a string pointer.
+    //call_method { name: Value, argc: u8 },
+    //call_method_pc { name: Value, argc: u8, class_id: ClassId, entry_pc: u32, fun_id: FunId, num_locals: u16 },
+    //call_method_host { name: Value, argc: u8, type_tag: Type, host_fn: &'static HostFn },
+
+    // Return the value found in a register
     ret { src: reg },
 
     // Return nil, as functions with no explicit return value do
@@ -488,7 +558,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 39);
+        assert_eq!(NUM_OPCODES, 58);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.
@@ -601,8 +671,19 @@ mod tests
         assert!(!Insn::fits(32, 5, false));
         assert!(Insn::fits(63, 6, false));
         assert!(!Insn::fits(64, 6, false));
+        assert!(Insn::fits(4095, 12, false));
+        assert!(!Insn::fits(4096, 12, false));
+        assert!(Insn::fits((1 << 24) - 1, 24, false));
+        assert!(!Insn::fits(1 << 24, 24, false));
         assert!(Insn::fits(-8, 4, true));
         assert!(!Insn::fits(-9, 4, true));
+    }
+
+    #[test]
+    fn u32_operand()
+    {
+        let insn = Insn::get_global(3, u32::MAX);
+        assert_eq!(get_global::decode(insn), get_global { dst: 3, idx: u32::MAX });
     }
 
     #[test]

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -61,8 +61,16 @@ macro_rules! def_opcodes {
     }
 }
 
-// Note: no instructions should directly handle system resources such as
-// input and output devices in order to enable sandboxing.
+// Notes:
+// - No instructions should directly handle system resources such as
+//   input and output devices in order to enable sandboxing. This should be
+//   done through host functions instead.
+// - Future rest arguments will be handled by allocating an array,
+//   which avoids the complexity of frames with variable arg counts
+// - Calls:
+//   - The design uses register windows like Lua
+//   - The callee's frame base is caller_bp + start_reg
+//   - Future tail calls can just mutate the frame in-place
 def_opcodes! {
     // Halt execution and produce an error
     // Panic is zero so that jumping to uninitialized memory causes panic
@@ -74,9 +82,10 @@ def_opcodes! {
     // Can be used for code patching, or to disable breakpoints
     nop { num_opnds = 0 },
 
-    // Load a sign-extended i32 immediate into a register
-    // load_const | dst_reg: u16 | imm: i32
-    imm_i32 { num_opnds = 2, num_outs = 1 },
+    // Load a sign-extended immediate into a register as the raw bits of a value.
+    // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
+    // load_imm32 | dst_reg: u16 | imm: i32
+    load_imm32 { num_opnds = 2, num_outs = 1 },
 
     // Copy a value from one register to another
     // mov | dst_reg: u16 | src_reg: u16
@@ -141,23 +150,26 @@ def_opcodes! {
     // jmp | offset: i32
     jmp { num_opnds = 1 },
 
-    // call | slot_idx: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
-    call { num_opnds = 4 },
+    // call | slot_idx: u16 | start_reg: u16 | num_args: u8
+    call { num_opnds = 3 },
 
-    // call_host | host_fn_id: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
-    call_host { num_opnds = 4 },
+    // call_host | host_fn_id: u16 | start_reg: u16 | num_args: u8
+    call_host { num_opnds = 3 },
 
     // TODO: we need to be able to call function pointers for doom
     // call_ptr {}
 
-    // Return zero values
-    ret0 { num_opnds = 0 },
+    // Return the value in a register
+    // ret | src_reg: u16
+    ret { num_opnds = 1 },
 
-    // Return one value
-    ret1 { num_opnds = 1 },
+    // Return nil, as functions with no explicit return value do
+    ret_nil { num_opnds = 0 },
 
-    // Return an int32 constant
-    ret_i32 { num_opnds = 1 },
+    // Return a sign-extended immediate as the raw bits of a value.
+    // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
+    // ret_imm32 | imm: i32
+    ret_imm32 { num_opnds = 1 },
 }
 
 /// Interpreter instruction
@@ -298,15 +310,14 @@ impl Insn
         )
     }
 
-    // call | slot_idx: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
-    pub fn encode_call(op: Opcode, slot_idx: u16, start_reg: u16, num_args: u8, num_ret: u8) -> Self
+    // call | slot_idx: u16 | start_reg: u16 | num_args: u8
+    pub fn encode_call(op: Opcode, slot_idx: u16, start_reg: u16, num_args: u8) -> Self
     {
         Insn(
             (op as u64) |
             (slot_idx as u64) << 16 |
             (start_reg as u64) << 32 |
-            (num_args as u64) << 48 |
-            (num_ret as u64) << 56
+            (num_args as u64) << 48
         )
     }
 }

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -23,6 +23,7 @@ macro_rules! opnd_width {
     (u8) => { 8 };
     (u12) => { 12 };
     (u16) => { 16 };
+    (u20) => { 20 };
     (u24) => { 24 };
     (u32) => { 32 };
     (i16) => { 16 };
@@ -45,6 +46,7 @@ macro_rules! opnd_type {
     (u8) => { u8 };
     (u12) => { u16 };
     (u16) => { u16 };
+    (u20) => { u32 };
     (u24) => { u32 };
     (u32) => { u32 };
     (i16) => { i16 };
@@ -146,10 +148,13 @@ macro_rules! gen_encode {
     };
 }
 
-// Check that an operand value is in range for the field it is encoded into
+// Check that an operand value is in range for the field it is encoded
+// into. This is a hard assert because encoding happens at compile time,
+// not in the interpreter loop, and an operand that silently gets truncated
+// here produces a wrong instruction rather than a crash
 macro_rules! check_opnd {
     ($fname:ident, $kind:ident) => {
-        debug_assert!(
+        assert!(
             Insn::fits($fname as i64, opnd_width!($kind), opnd_signed!($kind)),
             concat!("operand `", stringify!($fname), "` does not fit in ", stringify!($kind))
         );
@@ -292,7 +297,10 @@ macro_rules! def_opcodes {
             }
 
             /// Replace the branch displacement of a jump instruction.
-            /// Instructions with no displacement are returned unchanged.
+            /// The displacement is counted in instructions, relative to the
+            /// one following the branch, so a displacement of zero falls
+            /// through. Instructions with no displacement are returned
+            /// unchanged.
             #[allow(unused_variables)]
             pub fn with_branch_disp(self, disp: i32) -> Insn
             {
@@ -352,9 +360,13 @@ macro_rules! def_opcodes {
 // - Sites that cache a lookup hold a CacheIdx instead of the cached data,
 //   which keeps them within one word and lets cache entries grow later
 def_opcodes! {
-    // Halt execution and produce an error
+    // Halt execution and produce an error. The source position is packed
+    // into the operands so that the error can be reported without a side
+    // table. The fields are wider than any real source file needs, but a
+    // generated one could overflow them, so the caller saturates rather
+    // than letting the encoding assert fire.
     // Panic is zero so that jumping to uninitialized memory causes panic
-    panic = 0 {},
+    panic = 0 { file_id: u12, line_no: u24, col_no: u20 },
 
     // Debugger breakpoint
     breakpoint {},
@@ -624,7 +636,32 @@ mod tests
     #[test]
     fn panic_is_zero()
     {
-        assert_eq!(Insn::panic().word_u64(), 0);
+        assert_eq!(Insn::panic(0, 0, 0).word_u64(), 0);
+    }
+
+    #[test]
+    fn panic_src_pos()
+    {
+        // The three fields fill the word exactly, so each one has to come
+        // back out without disturbing the others
+        let insn = Insn::panic((1 << 12) - 1, (1 << 24) - 1, (1 << 20) - 1);
+        assert_eq!(
+            panic::decode(insn),
+            panic { file_id: (1 << 12) - 1, line_no: (1 << 24) - 1, col_no: (1 << 20) - 1 }
+        );
+        assert_eq!(insn.word_u64(), u64::MAX & !0xFF);
+
+        assert_eq!(panic::decode(Insn::panic(3, 0, 0)), panic { file_id: 3, line_no: 0, col_no: 0 });
+        assert_eq!(panic::decode(Insn::panic(0, 3, 0)), panic { file_id: 0, line_no: 3, col_no: 0 });
+        assert_eq!(panic::decode(Insn::panic(0, 0, 3)), panic { file_id: 0, line_no: 0, col_no: 3 });
+    }
+
+    #[test]
+    #[should_panic(expected = "does not fit")]
+    fn out_of_range_operand()
+    {
+        // Range checks are hard asserts, so this fires in release too
+        Insn::panic(1 << 12, 0, 0);
     }
 
     #[test]

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -470,20 +470,14 @@ def_opcodes! {
     call_host { host_fn: u16, start_reg: reg, argc: u8 },
 
     // Call a known function by its id
+    // This gets optimized into call_pc once the callee has been compiled
     call_direct { fun: u24, start_reg: reg, argc: u8 },
 
-    // FIXME: here we don't have a function id to produce stack traces...
-    // Ideally we'd have a map of bytecode positions to source locations?
-    // Currently our stack frames expect a function id
-    //
-    // Call an already compiled function by jumping to its entry point.
-    // The callee is statically known, so there is nothing to guard on and
-    // no cache entry. The argument count was checked when the call was
-    // specialized, and register windows do not need it at runtime, so it
-    // is not encoded here. The function id is not either: a stack trace can
-    // map an entry pc back to a function on the cold path.
-    // If a call cannot be specialized, the unoptimized form is used instead
-    call_pc { entry_pc: u24, start_reg: reg, num_locals: u16 },
+    // The callee is statically known, so there is nothing to guard on.
+    // We still use a cache entry because we can't fit all of the parameters
+    // directly into one 64-bit instruction, but this instruction will
+    // not deoptimize.
+    call_pc { start_reg: reg, num_locals: u16, cache: u24 },
 
     // Call a method on the object in start_reg. The method name, and the
     // class it was last looked up on, live in the CallCache entry

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -423,8 +423,10 @@ def_opcodes! {
 
     // FIXME: figure out solution wrt string operands
     // These name the field with a string pointer
-    //get_field { field: Value, class_id: ClassId, slot_idx: u32 },
-    //set_field { field: Value, class_id: ClassId, slot_idx: u32 },
+    //
+    // The class id and slot_idx values are cached by the instruction
+    //get_field { obj: reg, field: Value, class_id: u24, slot_idx: u16 },
+    //set_field { obj, reg, field: Value, class_id: u24, slot_idx: u16 },
 
     // Get/set indexed element
     get_index { dst: out_reg, arr: reg, idx: reg },

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -1,0 +1,312 @@
+#![allow(dead_code)]
+use std::mem::transmute;
+
+// Helper macro to define instruction opcodes and associated metadata
+macro_rules! def_opcodes {
+    (
+        $(
+            $(#[doc = $doc:expr])*
+            $name:ident {
+                $(op = $val:expr,)?
+                num_opnds = $num_opnds:expr
+                $(, num_outs = $num_outs:expr)?
+                $(,)?
+            },
+        )*
+    ) => {
+        pub const NUM_OPCODES: usize = 0 $( + { let _ = stringify!($name); 1 } )*;
+
+        /// Instruction opcodes
+        #[allow(non_camel_case_types)]
+        #[derive(PartialEq, Copy, Clone, Debug)]
+        #[repr(u16)]
+        pub enum Opcode
+        {
+            $(
+                $(#[doc = $doc])*
+                $name $(= $val)?,
+            )*
+        }
+
+        impl Opcode
+        {
+            pub fn num_opnds(self) -> usize
+            {
+                match self {
+                    $(
+                        Opcode::$name => $num_opnds,
+                    )*
+                }
+            }
+
+            pub fn num_outs(self) -> usize
+            {
+                match self {
+                    $(
+                        Opcode::$name => 0 $(+ $num_outs)?,
+                    )*
+                }
+            }
+
+            pub fn from_str(s: &str) -> Option<Self>
+            {
+                match s {
+                    $(
+                        stringify!($name) => Some(Opcode::$name),
+                    )*
+                    _ => None
+                }
+            }
+        }
+    }
+}
+
+// Note: no instructions should directly handle system resources such as
+// input and output devices in order to enable sandboxing.
+def_opcodes! {
+    // Halt execution and produce an error
+    // Panic is zero so that jumping to uninitialized memory causes panic
+    panic { op = 0, num_opnds = 0 },
+
+    // Debugger breakpoint
+    breakpoint { num_opnds = 0 },
+
+    // Can be used for code patching, or to disable breakpoints
+    nop { num_opnds = 0 },
+
+    // Load a sign-extended i32 immediate into a register
+    // load_const | dst_reg: u16 | imm: i32
+    imm_i32 { num_opnds = 2, num_outs = 1 },
+
+    // Copy a value from one register to another
+    // mov | dst_reg: u16 | src_reg: u16
+    mov { num_opnds = 2, num_outs = 1 },
+
+    // Load a constant from a constant slot into a register
+    // load_const | dst_reg: u16 | slot_idx: u16
+    load_const { num_opnds = 2, num_outs = 1 },
+
+    // Note: we might want to be able to use a constant slot for the base?
+    // load_uxx | dst_reg: u16 | base_reg: u16 | offset: u16
+    load_u8 { num_opnds = 3, num_outs = 1 },
+    load_u16 { num_opnds = 3, num_outs = 1 },
+    load_u32 { num_opnds = 3, num_outs = 1 },
+    load_u64 { num_opnds = 3, num_outs = 1 },
+
+    // Store is encoded the same way as load for simplicity
+    // store_uxx | src_reg: u16 | base_reg: u16 | offset: u16
+    store_u8 { num_opnds = 3 },
+    store_u16 { num_opnds = 3 },
+    store_u32 { num_opnds = 3 },
+    store_u64 { num_opnds = 3 },
+
+    // 32-bit bitwise operations
+    //not_u32,
+    lshift_u32 { num_opnds = 3, num_outs = 1 },
+    rshift_u32 { num_opnds = 3, num_outs = 1 },
+    rshift_i32 { num_opnds = 3, num_outs = 1 },
+    and_u32 { num_opnds = 3, num_outs = 1 },
+    or_u32 { num_opnds = 3, num_outs = 1 },
+    xor_u32 { num_opnds = 3, num_outs = 1 },
+
+    // op | dst_reg | reg0 | reg1
+    add_i32 { num_opnds = 3, num_outs = 1 },
+    sub_i32 { num_opnds = 3, num_outs = 1 },
+    mul_i32 { num_opnds = 3, num_outs = 1 },
+    div_i32 { num_opnds = 3, num_outs = 1 },
+    mod_i32 { num_opnds = 3, num_outs = 1 },
+    div_u32 { num_opnds = 3, num_outs = 1 },
+    mod_u32 { num_opnds = 3, num_outs = 1 },
+
+    // op | dst_reg:u16 | reg0:u16 | imm:i16
+    add_i32_imm { num_opnds = 3, num_outs = 1 },
+    sub_i32_imm { num_opnds = 3, num_outs = 1 },
+    mul_i32_imm { num_opnds = 3, num_outs = 1 },
+    div_i32_imm { num_opnds = 3, num_outs = 1 },
+    mod_i32_imm { num_opnds = 3, num_outs = 1 },
+
+    // jxx | r0: u16 | r1: u16 | offset: i16
+    jeq_i32 { num_opnds = 3 },
+    jne_i32 { num_opnds = 3 },
+    jlt_i32 { num_opnds = 3 },
+    jle_i32 { num_opnds = 3 },
+    jgt_i32 { num_opnds = 3 },
+    jge_i32 { num_opnds = 3 },
+    //jlt_u32 { num_opnds = 3 },
+    //jle_u32 { num_opnds = 3 },
+    //jgt_u32 { num_opnds = 3 },
+    //jge_u32 { num_opnds = 3 },
+
+    // Unconditional jump
+    // jmp | offset: i32
+    jmp { num_opnds = 1 },
+
+    // call | slot_idx: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
+    call { num_opnds = 4 },
+
+    // call_host | host_fn_id: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
+    call_host { num_opnds = 4 },
+
+    // TODO: we need to be able to call function pointers for doom
+    // call_ptr {}
+
+    // Return zero values
+    ret0 { num_opnds = 0 },
+
+    // Return one value
+    ret1 { num_opnds = 1 },
+
+    // Return an int32 constant
+    ret_i32 { num_opnds = 1 },
+}
+
+/// Interpreter instruction
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub struct Insn(u64);
+
+impl Insn
+{
+    #[inline(always)]
+    pub fn opcode(&self) -> Opcode
+    {
+        let Insn(word) = self;
+        unsafe { transmute(*word as u16) }
+    }
+
+    /// Get a register operand
+    #[inline(always)]
+    pub fn reg(&self, idx: u16) -> u16
+    {
+        assert!(idx < 3);
+        let Insn(word) = self;
+        let shift = (idx + 1) * 16;
+        ((word >> shift) & 0xFFFF) as u16
+    }
+
+    /// Get an immediate i32 value at the end of the instruction word
+    #[inline(always)]
+    pub fn imm_i32(&self) -> i32
+    {
+        (self.0 >> 32) as i32
+    }
+
+    /// Get an immediate i16 value at the end of the instruction word
+    #[inline(always)]
+    pub fn imm_i16(&self) -> i16
+    {
+        (self.0 >> 48) as i16
+    }
+
+    /// Get an immediate u16 value at the end of the instruction word
+    #[inline(always)]
+    pub fn imm_u16(&self) -> u16
+    {
+        (self.0 >> 48) as u16
+    }
+
+    /// Get the full u64 instruction word
+    #[inline(always)]
+    pub fn word_u64(&self) -> u64
+    {
+        let Insn(word) = self;
+        *word
+    }
+
+    pub fn encode_op(op: Opcode) -> Self
+    {
+        Insn(op as u64)
+    }
+
+    /// Encode an instruction with a i32 operand
+    pub fn encode_i32(op: Opcode, imm: i32) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (imm as u64) << 32
+        )
+    }
+
+    /// Encode an instruction with a single register operand
+    pub fn encode_1reg(op: Opcode, r0: u16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16
+        )
+    }
+
+    /// Encode an instruction one register and one imm32 operand
+    pub fn encode_reg_i32(op: Opcode, r0: u16, imm: i32) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (imm as u64) << 32
+        )
+    }
+
+    /// Encode an instruction one register and one u16 operand
+    pub fn encode_reg_u16(op: Opcode, r0: u16, imm: u16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (imm as u64) << 48
+        )
+    }
+
+    /// Encode an instruction with 3 register operands
+    pub fn encode_3reg(op: Opcode, r0: u16, r1: u16, r2: u16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (r1 as u64) << 32 |
+            (r2 as u64) << 48
+        )
+    }
+
+    /// Encode an instruction with 2 register operands
+    pub fn encode_2reg(op: Opcode, r0: u16, r1: u16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (r1 as u64) << 32
+        )
+    }
+
+    /// Encode an instruction with 2 register operands and one i16 imm
+    pub fn encode_2reg_i16(op: Opcode, r0: u16, r1: u16, imm: i16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (r1 as u64) << 32 |
+            (imm as u64) << 48
+        )
+    }
+
+    /// Encode an instruction with 2 register operands and one u16 imm
+    pub fn encode_2reg_u16(op: Opcode, r0: u16, r1: u16, imm: u16) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (r0 as u64) << 16 |
+            (r1 as u64) << 32 |
+            (imm as u64) << 48
+        )
+    }
+
+    // call | slot_idx: u16 | start_reg: u16 | num_args: u8 | num_ret: u8
+    pub fn encode_call(op: Opcode, slot_idx: u16, start_reg: u16, num_args: u8, num_ret: u8) -> Self
+    {
+        Insn(
+            (op as u64) |
+            (slot_idx as u64) << 16 |
+            (start_reg as u64) << 32 |
+            (num_args as u64) << 48 |
+            (num_ret as u64) << 56
+        )
+    }
+}

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -343,7 +343,14 @@ macro_rules! def_opcodes {
 // - Calls:
 //   - The design uses register windows like Lua
 //   - The callee's frame base is caller_bp + start_reg
+//   - The return value is written to the callee's frame base, which is
+//     start_reg in the caller. Calls therefore need no destination operand
 //   - Future tail calls can just mutate the frame in-place
+// - Field and method names are NameIds, indices into an interned name
+//   table that lives outside the heap. Instructions hold no heap pointers,
+//   so the instruction stream is not scanned by the collector
+// - Sites that cache a lookup hold a CacheIdx instead of the cached data,
+//   which keeps them within one word and lets cache entries grow later
 def_opcodes! {
     // Halt execution and produce an error
     // Panic is zero so that jumping to uninitialized memory causes panic
@@ -362,9 +369,8 @@ def_opcodes! {
     // Copy a value from one register to another
     mov { dst: out_reg, src: reg },
 
-    // FIXME: not fully clear how this will work yet. May want a 32-bit index?
     // Load a constant from a constant slot into a register
-    load_const { dst: out_reg, slot: u16 },
+    load_const { dst: out_reg, slot: u32 },
 
     // Note: we might want to be able to use a constant slot for the base?
     load_u8 { dst: out_reg, base: reg, offset: u16 },
@@ -415,18 +421,16 @@ def_opcodes! {
     cell_get { dst: out_reg, cell: reg },
 
     // Creating a class instance runs a constructor, so it is a call
-    new { class_id: u24, argc: u8 },
+    new { class_id: u24, start_reg: reg, argc: u8 },
     //new_known_ctor { class_id: ClassId, argc: u8, num_slots: u16, ctor_pc: u32, fun_id: FunId, num_locals: u16 },
 
     // Check if instance of class
-    instanceof { dst: out_reg, val: reg, class_id: u16 },
+    instanceof { dst: out_reg, val: reg, class_id: u24 },
 
-    // FIXME: figure out solution wrt string operands
-    // These name the field with a string pointer
-    //
-    // The class id and slot_idx values are cached by the instruction
-    //get_field { obj: reg, field: Value, class_id: u24, slot_idx: u16 },
-    //set_field { obj, reg, field: Value, class_id: u24, slot_idx: u16 },
+    // The field name, class id and slot index all live in the PropCache
+    // entry, which is what keeps these within one word
+    get_field { dst: out_reg, obj: reg, cache: u24 },
+    set_field { obj: reg, src: reg, cache: u24 },
 
     // Get/set indexed element
     get_index { dst: out_reg, arr: reg, idx: reg },
@@ -436,7 +440,7 @@ def_opcodes! {
     dict_new { dst: out_reg },
 
     // Array operations
-    arr_new { dst: out_reg, capacity: u16 },
+    arr_new { dst: out_reg, capacity: u32 },
     arr_push { arr: reg, val: reg },
 
     // Clone a bytearray
@@ -458,25 +462,32 @@ def_opcodes! {
     // Unconditional jump
     jmp { disp: disp32 },
 
-    // Call a function operand (dynamic call)
-    call { fun: reg,  start_reg: reg, argc: u8 },
+    // Call a function operand (dynamic call). The callee is not known, so
+    // the site caches the last one it resolved and guards on it
+    call_opnd { start_reg: reg, argc: u8, cache: u24 },
 
-    // Call a host function provided by the VM
-    call_host { host_fn: u16, start_reg: reg, num_args: u8 },
+    // Call a known host function provided by the VM
+    call_host { host_fn: u16, start_reg: reg, argc: u8 },
 
-    // Call a known function by id
-    call_direct { fun: u24, start_reg: reg, num_args: u8 },
+    // Call a known function by its id
+    call_direct { fun: u24, start_reg: reg, argc: u8 },
 
-    // Call an already compiled function with a known pc
-    // If we can't encode this call, we simply don't use this specialized instruction
-    call_pc { entry_pc: u24, fun_id: u16, num_locals: u8, argc: u8 },
+    // FIXME: here we don't have a function id to produce stack traces...
+    // Ideally we'd have a map of bytecode positions to source locations?
+    // Currently our stack frames expect a function id
+    //
+    // Call an already compiled function by jumping to its entry point.
+    // The callee is statically known, so there is nothing to guard on and
+    // no cache entry. The argument count was checked when the call was
+    // specialized, and register windows do not need it at runtime, so it
+    // is not encoded here. The function id is not either: a stack trace can
+    // map an entry pc back to a function on the cold path.
+    // If a call cannot be specialized, the unoptimized form is used instead
+    call_pc { entry_pc: u24, start_reg: reg, num_locals: u16 },
 
-    // Call encodings still to be figured out. Brought over from the old VM
-    // as-is. The inline caches need somewhere to live, and the method calls
-    // name the method with a string pointer.
-    //call_method { name: Value, argc: u8 },
-    //call_method_pc { name: Value, argc: u8, class_id: ClassId, entry_pc: u32, fun_id: FunId, num_locals: u16 },
-    //call_method_host { name: Value, argc: u8, type_tag: Type, host_fn: &'static HostFn },
+    // Call a method on the object in start_reg. The method name, and the
+    // class it was last looked up on, live in the CallCache entry
+    call_method { start_reg: reg, argc: u8, cache: u24 },
 
     // Return the value found in a register
     ret { src: reg },
@@ -487,6 +498,45 @@ def_opcodes! {
     // Return a sign-extended immediate as the raw bits of a value.
     // Covers nil, undef, booleans and fixnums in the +/- 2^29 range
     ret_imm32 { imm: i32 },
+}
+
+// Sketch of the side tables the instructions above index into. These will
+// likely move next to the code they are used by once the VM is written.
+
+/// Index into the program's interned name table, which holds field and
+/// method names. Names are immortal and live outside the heap, so they
+/// never move and never need to be traced
+pub type NameId = u32;
+
+/// Index into a function's array of inline cache entries
+pub type CacheIdx = u32;
+
+/// Cache for a field access site
+pub struct PropCache
+{
+    pub name: NameId,
+
+    // Class the field was last looked up on, and where it was found.
+    // The slot index is only valid for objects of that class
+    pub class_id: u32,
+    pub slot_idx: u32,
+}
+
+/// Cache for a call site whose callee is not statically known. Dynamic
+/// calls guard on the function they last resolved to, method calls on the
+/// class they last looked the name up on. A statically known callee needs
+/// no entry here: it becomes a call_pc instead
+pub struct CallCache
+{
+    pub name: NameId,
+    pub class_id: u32,
+
+    // Callee the site resolved to. The function id is both the guard and
+    // what the stack frame records, and the frame needs the entry point
+    // and its own size
+    pub fun_id: u32,
+    pub entry_pc: u32,
+    pub num_locals: u16,
 }
 
 /// Interpreter instruction
@@ -560,7 +610,7 @@ mod tests
     {
         // Update this when adding opcodes, it is here to make the size of
         // the instruction set visible as it grows
-        assert_eq!(NUM_OPCODES, 58);
+        assert_eq!(NUM_OPCODES, 64);
 
         // Opcodes are dense from zero, so this is the highest opcode value.
         // It has to stay below 255 to leave room for a future extension.
@@ -652,10 +702,17 @@ mod tests
     fn operands_do_not_overlap()
     {
         // Each operand set on its own must leave the others zero
-        assert_eq!(call::decode(Insn::call(u16::MAX, 0, 0)).start_reg, 0);
-        assert_eq!(call::decode(Insn::call(0, u16::MAX, 0)).fun, 0);
-        assert_eq!(call::decode(Insn::call(0, 0, u8::MAX)).fun, 0);
-        assert_eq!(call::decode(Insn::call(1, 2, 3)), call { fun: 1, start_reg: 2, num_args: 3 });
+        assert_eq!(call_host::decode(Insn::call_host(u16::MAX, 0, 0)).start_reg, 0);
+        assert_eq!(call_host::decode(Insn::call_host(0, u16::MAX, 0)).host_fn, 0);
+        assert_eq!(call_host::decode(Insn::call_host(0, 0, u8::MAX)).host_fn, 0);
+        assert_eq!(
+            call_host::decode(Insn::call_host(1, 2, 3)),
+            call_host { host_fn: 1, start_reg: 2, argc: 3 }
+        );
+
+        // A top-aligned u24 sitting above a u8
+        assert_eq!(call_opnd::decode(Insn::call_opnd(0, 0, (1 << 24) - 1)).argc, 0);
+        assert_eq!(call_opnd::decode(Insn::call_opnd(0, u8::MAX, 0)).cache, 0);
     }
 
     #[test]
@@ -714,6 +771,6 @@ mod tests
         assert_eq!(Insn::add_imm16(1, 2, -3).to_string(), "add_imm16 r1, r2, -3");
         assert_eq!(Insn::jlt(4, 5, -6).to_string(), "jlt r4, r5, -6");
         assert_eq!(Insn::ret_nil().to_string(), "ret_nil");
-        assert_eq!(Insn::call(7, 8, 9).to_string(), "call 7, r8, 9");
+        assert_eq!(Insn::call_host(7, 8, 9).to_string(), "call_host 7, r8, 9");
     }
 }

--- a/src/insns.rs
+++ b/src/insns.rs
@@ -370,7 +370,7 @@ def_opcodes! {
     // generated one could overflow them, so the caller saturates rather
     // than letting the encoding assert fire.
     // Panic is zero so that jumping to uninitialized memory causes panic
-    panic = 0 { file_id: u12, line_no: u24, col_no: u20 },
+    panic = 0 { file_id: u16, line_no: u20, col_no: u20 },
 
     // Debugger breakpoint
     breakpoint {},
@@ -464,7 +464,12 @@ def_opcodes! {
     jmp { disp: disp32 },
 
     // Call a function operand (dynamic call). The callee is not known, so
-    // the site caches the last one it resolved and guards on it
+    // the site caches the last one it resolved and guards on it.
+    // The callee sits in start_reg + argc, just past the arguments, which
+    // is where the callee's own frame overwrites it once the call is
+    // under way. Naming it there rather than in an operand is what leaves
+    // room for the cache, and it keeps the return value in start_reg like
+    // every other call
     call_opnd { start_reg: reg, argc: u8, cache: u24 },
 
     // Call a known host function provided by the VM
@@ -650,10 +655,10 @@ mod tests
     {
         // The three fields fill the word exactly, so each one has to come
         // back out without disturbing the others
-        let insn = Insn::panic((1 << 12) - 1, (1 << 24) - 1, (1 << 20) - 1);
+        let insn = Insn::panic(u16::MAX, (1 << 20) - 1, (1 << 20) - 1);
         assert_eq!(
             panic::decode(insn),
-            panic { file_id: (1 << 12) - 1, line_no: (1 << 24) - 1, col_no: (1 << 20) - 1 }
+            panic { file_id: u16::MAX, line_no: (1 << 20) - 1, col_no: (1 << 20) - 1 }
         );
         assert_eq!(insn.word_u64(), u64::MAX & !0xFF);
 
@@ -667,7 +672,7 @@ mod tests
     fn out_of_range_operand()
     {
         // Range checks are hard asserts, so this fires in release too
-        Insn::panic(1 << 12, 0, 0);
+        Insn::panic(0, 1 << 20, 0);
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -38,7 +38,7 @@ fn get_file_id(name: &str) -> u32
 }
 
 /// Get the file name associated with a unique id
-fn name_from_id(id: u32) -> String
+pub fn name_from_id(id: u32) -> String
 {
     let id = id as usize;
     let map = get_file_id_map().lock().unwrap();
@@ -60,6 +60,10 @@ impl SrcPos
     {
         name_from_id(self.file_id)
     }
+
+    pub fn file_id(&self) -> u32 { self.file_id }
+    pub fn line_no(&self) -> u32 { self.line_no }
+    pub fn col_no(&self) -> u32 { self.col_no }
 }
 
 impl fmt::Display for SrcPos

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod parser;
 mod symbols;
 mod codegen;
 mod vm;
+mod insns;
 mod value;
 mod alloc;
 mod object;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,53 +5,58 @@ use crate::value::*;
 use crate::str::Str;
 use crate::*;
 
-fn identity_method(_actor: &mut Actor, self_val: Value) -> Result<Value, String>
+pub(crate) fn identity_method(_actor: &mut Actor, self_val: Value) -> Result<Value, String>
 {
     Ok(self_val)
 }
 
-fn true_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
+// `to_f` on a float and `to_s` on a string both hand back self. They are
+// named here so that the host function table can find them by id
+pub(crate) use self::identity_method as float64_to_f;
+pub(crate) use self::identity_method as string_to_s;
+
+pub(crate) fn true_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
     Ok(actor.intern_str("true"))
 }
 
-fn false_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
+pub(crate) fn false_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
     Ok(actor.intern_str("false"))
 }
 
-fn nil_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
+pub(crate) fn nil_to_s(actor: &mut Actor, _v: Value) -> Result<Value, String>
 {
     Ok(actor.intern_str("nil"))
 }
 
-fn int64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn int64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     Ok(actor.int64(if v > 0 { v } else { -v }))
 }
 
-fn int64_min(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
+pub(crate) fn int64_min(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     let other = unwrap_i64!(other);
     Ok(actor.int64(v.min(other)))
 }
 
-fn int64_max(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
+pub(crate) fn int64_max(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     let other = unwrap_i64!(other);
     Ok(actor.int64(v.max(other)))
 }
 
-fn int64_to_f(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn int64_to_f(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     Ok(actor.float64(v as f64))
 }
 
-fn int64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn int64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     let s = format!("{}", v);
@@ -60,7 +65,7 @@ fn int64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
     Ok(Str::new(&s, &mut actor.alloc))
 }
 
-fn int64_to_hex(actor: &mut Actor, v: Value, digits: Value) -> Result<Value, String>
+pub(crate) fn int64_to_hex(actor: &mut Actor, v: Value, digits: Value) -> Result<Value, String>
 {
     let v = unwrap_i64!(v);
     let digits = unwrap_usize!(digits);
@@ -70,13 +75,13 @@ fn int64_to_hex(actor: &mut Actor, v: Value, digits: Value) -> Result<Value, Str
     Ok(Str::new(&s, &mut actor.alloc))
 }
 
-fn float64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_abs(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(if v > 0.0 { v } else { -v }))
 }
 
-fn float64_ceil(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_ceil(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     // TODO: check that float value fits in integer range
     let v = unwrap_f64!(v);
@@ -84,7 +89,7 @@ fn float64_ceil(actor: &mut Actor, v: Value) -> Result<Value, String>
     Ok(actor.int64(int_val))
 }
 
-fn float64_floor(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_floor(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     // TODO: check that float value fits in integer range
     let v = unwrap_f64!(v);
@@ -92,7 +97,7 @@ fn float64_floor(actor: &mut Actor, v: Value) -> Result<Value, String>
     Ok(actor.int64(int_val))
 }
 
-fn float64_trunc(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_trunc(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     // TODO: check that float value fits in integer range
     let v = unwrap_f64!(v);
@@ -100,51 +105,51 @@ fn float64_trunc(actor: &mut Actor, v: Value) -> Result<Value, String>
     Ok(actor.int64(int_val))
 }
 
-fn float64_sin(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_sin(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.sin()))
 }
 
-fn float64_cos(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_cos(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.cos()))
 }
 
-fn float64_tan(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_tan(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.tan()))
 }
 
-fn float64_atan(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_atan(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.atan()))
 }
 
-fn float64_sqrt(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_sqrt(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.sqrt()))
 }
 
-fn float64_min(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
+pub(crate) fn float64_min(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     let other = unwrap_f64!(other);
     Ok(actor.float64(v.min(other)))
 }
 
-fn float64_max(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
+pub(crate) fn float64_max(actor: &mut Actor, v: Value, other: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     let other = unwrap_f64!(other);
     Ok(actor.float64(v.max(other)))
 }
 
-fn float64_clip(actor: &mut Actor, v: Value, min: Value, max: Value) -> Result<Value, String>
+pub(crate) fn float64_clip(actor: &mut Actor, v: Value, min: Value, max: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     let min = unwrap_f64!(min);
@@ -152,26 +157,26 @@ fn float64_clip(actor: &mut Actor, v: Value, min: Value, max: Value) -> Result<V
     Ok(actor.float64(v.clamp(min, max)))
 }
 
-fn float64_pow(actor: &mut Actor, v: Value, exponent: Value) -> Result<Value, String>
+pub(crate) fn float64_pow(actor: &mut Actor, v: Value, exponent: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     let exponent = unwrap_f64!(exponent);
     Ok(actor.float64(v.powf(exponent)))
 }
 
-fn float64_exp(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_exp(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.exp()))
 }
 
-fn float64_ln(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_ln(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     Ok(actor.float64(v.ln()))
 }
 
-fn float64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
+pub(crate) fn float64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
 {
     let v = unwrap_f64!(v);
     let s = format!("{}", v);
@@ -179,7 +184,7 @@ fn float64_to_s(actor: &mut Actor, v: Value) -> Result<Value, String>
     Ok(Str::new(&s, &mut actor.alloc))
 }
 
-fn float64_format_decimals(actor: &mut Actor, v: Value, decimals: Value) -> Result<Value, String>
+pub(crate) fn float64_format_decimals(actor: &mut Actor, v: Value, decimals: Value) -> Result<Value, String>
 {
     let num = unwrap_f64!(v);
     let decimals = unwrap_usize!(decimals);
@@ -189,7 +194,7 @@ fn float64_format_decimals(actor: &mut Actor, v: Value, decimals: Value) -> Resu
 }
 
 /// Create a single-character string from a codepoint integer value
-fn string_from_codepoint(actor: &mut Actor, _class: Value, codepoint: Value) -> Result<Value, String>
+pub(crate) fn string_from_codepoint(actor: &mut Actor, _class: Value, codepoint: Value) -> Result<Value, String>
 {
     // TODO: eventually we can add caching for this,
     // at least for ASCII character values, we can
@@ -206,7 +211,7 @@ fn string_from_codepoint(actor: &mut Actor, _class: Value, codepoint: Value) -> 
 }
 
 /// Get the UTF-8 byte at the given index
-fn string_byte_at(_actor: &mut Actor, s: Value, idx: Value) -> Result<Value, String>
+pub(crate) fn string_byte_at(_actor: &mut Actor, s: Value, idx: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let idx = unwrap_usize!(idx);
@@ -216,7 +221,7 @@ fn string_byte_at(_actor: &mut Actor, s: Value, idx: Value) -> Result<Value, Str
 
 /// Get a string containing the single character at the given byte index
 /// Returns nil if not a valid character boundary or character
-fn string_char_at(actor: &mut Actor, s: Value, byte_idx: Value) -> Result<Value, String>
+pub(crate) fn string_char_at(actor: &mut Actor, s: Value, byte_idx: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let byte_idx = unwrap_usize!(byte_idx);
@@ -244,7 +249,7 @@ fn string_char_at(actor: &mut Actor, s: Value, byte_idx: Value) -> Result<Value,
 }
 
 /// Try to parse the string as an integer with the given radix
-fn string_parse_int(actor: &mut Actor, s: Value, radix: Value) -> Result<Value, String>
+pub(crate) fn string_parse_int(actor: &mut Actor, s: Value, radix: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let radix = unwrap_u32!(radix);
@@ -256,7 +261,7 @@ fn string_parse_int(actor: &mut Actor, s: Value, radix: Value) -> Result<Value, 
 }
 
 /// Try to parse the string as a float
-fn string_parse_float(actor: &mut Actor, s: Value) -> Result<Value, String>
+pub(crate) fn string_parse_float(actor: &mut Actor, s: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
 
@@ -267,7 +272,7 @@ fn string_parse_float(actor: &mut Actor, s: Value) -> Result<Value, String>
 }
 
 /// Trim whitespace
-fn string_trim(actor: &mut Actor, s: Value) -> Result<Value, String>
+pub(crate) fn string_trim(actor: &mut Actor, s: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let s = s.trim().to_string();
@@ -276,7 +281,7 @@ fn string_trim(actor: &mut Actor, s: Value) -> Result<Value, String>
 }
 
 /// Uppercase a String
-fn string_upper(actor: &mut Actor, s: Value) -> Result<Value, String>
+pub(crate) fn string_upper(actor: &mut Actor, s: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let s = s.to_uppercase();
@@ -285,7 +290,7 @@ fn string_upper(actor: &mut Actor, s: Value) -> Result<Value, String>
 }
 
 /// Lowercase a String
-fn string_lower(actor: &mut Actor, s: Value) -> Result<Value, String>
+pub(crate) fn string_lower(actor: &mut Actor, s: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(s);
     let s = s.to_lowercase();
@@ -294,7 +299,7 @@ fn string_lower(actor: &mut Actor, s: Value) -> Result<Value, String>
 }
 
 /// Split a string by a separator and return an array of strings
-fn string_split(actor: &mut Actor, input: Value, sep: Value) -> Result<Value, String>
+pub(crate) fn string_split(actor: &mut Actor, input: Value, sep: Value) -> Result<Value, String>
 {
     let s = unwrap_str!(input);
     let sep = unwrap_str!(sep);
@@ -377,7 +382,7 @@ pub fn init_runtime(prog: &mut Program)
     prog.reg_class(audio_data);
 }
 
-fn dict_has(_actor: &mut Actor, d: Value, key: Value) -> Result<Value, String>
+pub(crate) fn dict_has(_actor: &mut Actor, d: Value, key: Value) -> Result<Value, String>
 {
     let d = unwrap_dict!(d);
     let key = unwrap_str!(key);
@@ -387,154 +392,83 @@ fn dict_has(_actor: &mut Actor, d: Value, key: Value) -> Result<Value, String>
 /// Get the method associated with a core value
 pub fn get_method(val: Value, method_name: &str) -> Value
 {
-    use crate::host::HostFn;
-    use crate::host::FnPtr::*;
-    use crate::array::*;
-    use crate::bytearray::*;
+    use crate::host::HostFnId::*;
 
-    static TRUE_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(true_to_s) };
-    static FALSE_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(false_to_s) };
-    static NIL_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(nil_to_s) };
-
-    static INT64_ABS: HostFn = HostFn { name: "abs", f: Fn1(int64_abs) };
-    static INT64_MIN: HostFn = HostFn { name: "min", f: Fn2(int64_min) };
-    static INT64_MAX: HostFn = HostFn { name: "max", f: Fn2(int64_max) };
-    static INT64_TO_F: HostFn = HostFn { name: "to_f", f: Fn1(int64_to_f) };
-    static INT64_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(int64_to_s) };
-    static INT64_TO_HEX: HostFn = HostFn { name: "to_hex", f: Fn2(int64_to_hex) };
-
-    static FLOAT64_ABS: HostFn = HostFn { name: "abs", f: Fn1(float64_abs) };
-    static FLOAT64_CEIL: HostFn = HostFn { name: "ceil", f: Fn1(float64_ceil) };
-    static FLOAT64_FLOOR: HostFn = HostFn { name: "floor", f: Fn1(float64_floor) };
-    static FLOAT64_TRUNC: HostFn = HostFn { name: "trunc", f: Fn1(float64_trunc) };
-    static FLOAT64_SIN: HostFn = HostFn { name: "sin", f: Fn1(float64_sin) };
-    static FLOAT64_COS: HostFn = HostFn { name: "cos", f: Fn1(float64_cos) };
-    static FLOAT64_TAN: HostFn = HostFn { name: "tan", f: Fn1(float64_tan) };
-    static FLOAT64_ATAN: HostFn = HostFn { name: "atan", f: Fn1(float64_atan) };
-    static FLOAT64_SQRT: HostFn = HostFn { name: "sqrt", f: Fn1(float64_sqrt) };
-    static FLOAT64_MIN: HostFn = HostFn { name: "min", f: Fn2(float64_min) };
-    static FLOAT64_MAX: HostFn = HostFn { name: "max", f: Fn2(float64_max) };
-    static FLOAT64_CLIP: HostFn = HostFn { name: "clip", f: Fn3(float64_clip) };
-    static FLOAT64_POW: HostFn = HostFn { name: "pow", f: Fn2(float64_pow) };
-    static FLOAT64_EXP: HostFn = HostFn { name: "exp", f: Fn1(float64_exp) };
-    static FLOAT64_LN: HostFn = HostFn { name: "ln", f: Fn1(float64_ln) };
-    static FLOAT64_TO_F: HostFn = HostFn { name: "to_f", f: Fn1(identity_method) };
-    static FLOAT64_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(float64_to_s) };
-    static FLOAT64_FORMAT_DECIMALS: HostFn = HostFn { name: "format_decimals", f: Fn2(float64_format_decimals) };
-
-    static STRING_FROM_CODEPOINT: HostFn = HostFn { name: "from_codepoint", f: Fn2(string_from_codepoint) };
-    static STRING_BYTE_AT: HostFn = HostFn { name: "byte_at", f: Fn2(string_byte_at) };
-    static STRING_CHAR_AT: HostFn = HostFn { name: "char_at", f: Fn2(string_char_at) };
-    static STRING_PARSE_INT: HostFn = HostFn { name: "parse_int", f: Fn2(string_parse_int) };
-    static STRING_PARSE_FLOAT: HostFn = HostFn { name: "parse_float", f: Fn1(string_parse_float) };
-    static STRING_TRIM: HostFn = HostFn { name: "trim", f: Fn1(string_trim) };
-    static STRING_UPPER: HostFn = HostFn { name: "upper", f: Fn1(string_upper) };
-    static STRING_LOWER: HostFn = HostFn { name: "lower", f: Fn1(string_lower) };
-    static STRING_SPLIT: HostFn = HostFn { name: "split", f: Fn2(string_split) };
-    static STRING_TO_S: HostFn = HostFn { name: "to_s", f: Fn1(identity_method) };
-
-    static ARRAY_WITH_SIZE: HostFn = HostFn { name: "with_size", f: Fn3(array_with_size) };
-    static ARRAY_PUSH: HostFn = HostFn { name: "push", f: Fn2(array_push) };
-    static ARRAY_POP: HostFn = HostFn { name: "pop", f: Fn1(array_pop) };
-    static ARRAY_REMOVE: HostFn = HostFn { name: "remove", f: Fn2(array_remove) };
-    static ARRAY_INSERT: HostFn = HostFn { name: "insert", f: Fn3(array_insert) };
-    static ARRAY_APPEND: HostFn = HostFn { name: "append", f: Fn2(array_append) };
-    static ARRAY_RESIZE: HostFn = HostFn { name: "resize", f: Fn3(array_resize) };
-
-    static BA_WITH_SIZE: HostFn = HostFn { name: "with_size", f: Fn2(ba_with_size) };
-    static BA_READ_U32: HostFn = HostFn { name: "load_u32", f: Fn2(ba_load_u32) };
-    static BA_WRITE_U32: HostFn = HostFn { name: "store_u32", f: Fn3(ba_store_u32) };
-    static BA_READ_U16: HostFn = HostFn { name: "load_u16", f: Fn2(ba_load_u16) };
-    static BA_WRITE_U16: HostFn = HostFn { name: "store_u16", f: Fn3(ba_store_u16) };
-    static BA_READ_F32: HostFn = HostFn { name: "load_f32", f: Fn2(ba_load_f32) };
-    static BA_WRITE_F32: HostFn = HostFn { name: "store_f32", f: Fn3(ba_store_f32) };
-    static BA_GET_U32: HostFn = HostFn { name: "get_u32", f: Fn2(ba_get_u32) };
-    static BA_SET_U32: HostFn = HostFn { name: "set_u32", f: Fn3(ba_set_u32) };
-    static BA_GET_F32: HostFn = HostFn { name: "get_f32", f: Fn2(ba_get_f32) };
-    static BA_SET_F32: HostFn = HostFn { name: "set_f32", f: Fn3(ba_set_f32) };
-    static BA_NUM_U32: HostFn = HostFn { name: "num_u32", f: Fn1(ba_num_u32) };
-    static BA_MEMCPY: HostFn = HostFn { name: "memcpy", f: Fn5(ba_memcpy) };
-    static BA_RESIZE: HostFn = HostFn { name: "resize", f: Fn2(ba_resize) };
-    static BA_ZERO_FILL: HostFn = HostFn { name: "zero_fill", f: Fn1(ba_zero_fill) };
-    static BA_FILL_U32: HostFn = HostFn { name: "fill_u32", f: Fn4(ba_fill_u32) };
-    static BA_BLIT_BGRA32: HostFn = HostFn { name: "blit_bgra32", f: Fn8(ba_blit_bgra32) };
-
-    static DICT_HAS: HostFn = HostFn { name: "has", f: Fn2(dict_has) };
 
     // Dispatch on the language-level type first, so that a value that
     // has no methods at all costs one branch and no string compares
     let f = match (val.type_of(), method_name) {
-        (Type::Int64, "abs") => &INT64_ABS,
-        (Type::Int64, "min") => &INT64_MIN,
-        (Type::Int64, "max") => &INT64_MAX,
-        (Type::Int64, "to_f") => &INT64_TO_F,
-        (Type::Int64, "to_s") => &INT64_TO_S,
-        (Type::Int64, "to_hex") => &INT64_TO_HEX,
+        (Type::Int64, "abs") => int64_abs,
+        (Type::Int64, "min") => int64_min,
+        (Type::Int64, "max") => int64_max,
+        (Type::Int64, "to_f") => int64_to_f,
+        (Type::Int64, "to_s") => int64_to_s,
+        (Type::Int64, "to_hex") => int64_to_hex,
 
-        (Type::Float64, "abs") => &FLOAT64_ABS,
-        (Type::Float64, "ceil") => &FLOAT64_CEIL,
-        (Type::Float64, "floor") => &FLOAT64_FLOOR,
-        (Type::Float64, "trunc") => &FLOAT64_TRUNC,
-        (Type::Float64, "sin") => &FLOAT64_SIN,
-        (Type::Float64, "cos") => &FLOAT64_COS,
-        (Type::Float64, "tan") => &FLOAT64_TAN,
-        (Type::Float64, "atan") => &FLOAT64_ATAN,
-        (Type::Float64, "sqrt") => &FLOAT64_SQRT,
-        (Type::Float64, "min") => &FLOAT64_MIN,
-        (Type::Float64, "max") => &FLOAT64_MAX,
-        (Type::Float64, "clip") => &FLOAT64_CLIP,
-        (Type::Float64, "pow") => &FLOAT64_POW,
-        (Type::Float64, "exp") => &FLOAT64_EXP,
-        (Type::Float64, "ln") => &FLOAT64_LN,
-        (Type::Float64, "to_f") => &FLOAT64_TO_F,
-        (Type::Float64, "to_s") => &FLOAT64_TO_S,
-        (Type::Float64, "format_decimals") => &FLOAT64_FORMAT_DECIMALS,
+        (Type::Float64, "abs") => float64_abs,
+        (Type::Float64, "ceil") => float64_ceil,
+        (Type::Float64, "floor") => float64_floor,
+        (Type::Float64, "trunc") => float64_trunc,
+        (Type::Float64, "sin") => float64_sin,
+        (Type::Float64, "cos") => float64_cos,
+        (Type::Float64, "tan") => float64_tan,
+        (Type::Float64, "atan") => float64_atan,
+        (Type::Float64, "sqrt") => float64_sqrt,
+        (Type::Float64, "min") => float64_min,
+        (Type::Float64, "max") => float64_max,
+        (Type::Float64, "clip") => float64_clip,
+        (Type::Float64, "pow") => float64_pow,
+        (Type::Float64, "exp") => float64_exp,
+        (Type::Float64, "ln") => float64_ln,
+        (Type::Float64, "to_f") => float64_to_f,
+        (Type::Float64, "to_s") => float64_to_s,
+        (Type::Float64, "format_decimals") => float64_format_decimals,
 
-        (Type::String, "byte_at") => &STRING_BYTE_AT,
-        (Type::String, "char_at") => &STRING_CHAR_AT,
-        (Type::String, "parse_int") => &STRING_PARSE_INT,
-        (Type::String, "parse_float") => &STRING_PARSE_FLOAT,
-        (Type::String, "trim") => &STRING_TRIM,
-        (Type::String, "upper") => &STRING_UPPER,
-        (Type::String, "lower") => &STRING_LOWER,
-        (Type::String, "split") => &STRING_SPLIT,
-        (Type::String, "to_s") => &STRING_TO_S,
+        (Type::String, "byte_at") => string_byte_at,
+        (Type::String, "char_at") => string_char_at,
+        (Type::String, "parse_int") => string_parse_int,
+        (Type::String, "parse_float") => string_parse_float,
+        (Type::String, "trim") => string_trim,
+        (Type::String, "upper") => string_upper,
+        (Type::String, "lower") => string_lower,
+        (Type::String, "split") => string_split,
+        (Type::String, "to_s") => string_to_s,
 
-        (Type::Array, "push") => &ARRAY_PUSH,
-        (Type::Array, "pop") => &ARRAY_POP,
-        (Type::Array, "remove") => &ARRAY_REMOVE,
-        (Type::Array, "insert") => &ARRAY_INSERT,
-        (Type::Array, "append") => &ARRAY_APPEND,
-        (Type::Array, "resize") => &ARRAY_RESIZE,
+        (Type::Array, "push") => array_push,
+        (Type::Array, "pop") => array_pop,
+        (Type::Array, "remove") => array_remove,
+        (Type::Array, "insert") => array_insert,
+        (Type::Array, "append") => array_append,
+        (Type::Array, "resize") => array_resize,
 
-        (Type::ByteArray, "load_u32") => &BA_READ_U32,
-        (Type::ByteArray, "store_u32") => &BA_WRITE_U32,
-        (Type::ByteArray, "load_u16") => &BA_READ_U16,
-        (Type::ByteArray, "store_u16") => &BA_WRITE_U16,
-        (Type::ByteArray, "load_f32") => &BA_READ_F32,
-        (Type::ByteArray, "store_f32") => &BA_WRITE_F32,
-        (Type::ByteArray, "get_u32") => &BA_GET_U32,
-        (Type::ByteArray, "set_u32") => &BA_SET_U32,
-        (Type::ByteArray, "get_f32") => &BA_GET_F32,
-        (Type::ByteArray, "set_f32") => &BA_SET_F32,
-        (Type::ByteArray, "num_u32") => &BA_NUM_U32,
-        (Type::ByteArray, "num_f32") => &BA_NUM_U32,
-        (Type::ByteArray, "memcpy") => &BA_MEMCPY,
-        (Type::ByteArray, "resize") => &BA_RESIZE,
-        (Type::ByteArray, "zero_fill") => &BA_ZERO_FILL,
-        (Type::ByteArray, "fill_u32") => &BA_FILL_U32,
-        (Type::ByteArray, "blit_bgra32") => &BA_BLIT_BGRA32,
+        (Type::ByteArray, "load_u32") => ba_load_u32,
+        (Type::ByteArray, "store_u32") => ba_store_u32,
+        (Type::ByteArray, "load_u16") => ba_load_u16,
+        (Type::ByteArray, "store_u16") => ba_store_u16,
+        (Type::ByteArray, "load_f32") => ba_load_f32,
+        (Type::ByteArray, "store_f32") => ba_store_f32,
+        (Type::ByteArray, "get_u32") => ba_get_u32,
+        (Type::ByteArray, "set_u32") => ba_set_u32,
+        (Type::ByteArray, "get_f32") => ba_get_f32,
+        (Type::ByteArray, "set_f32") => ba_set_f32,
+        (Type::ByteArray, "num_u32") => ba_num_u32,
+        (Type::ByteArray, "num_f32") => ba_num_u32,
+        (Type::ByteArray, "memcpy") => ba_memcpy,
+        (Type::ByteArray, "resize") => ba_resize,
+        (Type::ByteArray, "zero_fill") => ba_zero_fill,
+        (Type::ByteArray, "fill_u32") => ba_fill_u32,
+        (Type::ByteArray, "blit_bgra32") => ba_blit_bgra32,
 
-        (Type::Dict, "has") => &DICT_HAS,
+        (Type::Dict, "has") => dict_has,
 
-        (Type::Bool, "to_s") => if val.as_bool() { &TRUE_TO_S } else { &FALSE_TO_S },
-        (Type::Nil, "to_s") => &NIL_TO_S,
+        (Type::Bool, "to_s") => if val.as_bool() { true_to_s } else { false_to_s },
+        (Type::Nil, "to_s") => nil_to_s,
 
         // Static methods, called on the class itself
         (Type::Class, _) => match (val.as_class(), method_name) {
-            (STRING_ID, "from_codepoint") => &STRING_FROM_CODEPOINT,
-            (ARRAY_ID, "with_size") => &ARRAY_WITH_SIZE,
-            (BYTEARRAY_ID, "with_size") => &BA_WITH_SIZE,
+            (STRING_ID, "from_codepoint") => string_from_codepoint,
+            (ARRAY_ID, "with_size") => array_with_size,
+            (BYTEARRAY_ID, "with_size") => ba_with_size,
             _ => return Value::NIL,
         }
 
@@ -542,7 +476,7 @@ pub fn get_method(val: Value, method_name: &str) -> Value
         _ => return Value::NIL,
     };
 
-    Value::host_fn(f)
+    Value::host_fn(f.get())
 }
 
 pub fn get_class_id(val: Value) -> ClassId

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@ use crate::vm::Actor;
 use crate::value::*;
 use crate::str::Str;
 use crate::*;
+use crate::host::HostFnId;
 
 pub(crate) fn identity_method(_actor: &mut Actor, self_val: Value) -> Result<Value, String>
 {
@@ -390,10 +391,9 @@ pub(crate) fn dict_has(_actor: &mut Actor, d: Value, key: Value) -> Result<Value
 }
 
 /// Get the method associated with a core value
-pub fn get_method(val: Value, method_name: &str) -> Value
+pub fn get_method(val: Value, method_name: &str) -> Option<HostFnId>
 {
     use crate::host::HostFnId::*;
-
 
     // Dispatch on the language-level type first, so that a value that
     // has no methods at all costs one branch and no string compares
@@ -469,14 +469,14 @@ pub fn get_method(val: Value, method_name: &str) -> Value
             (STRING_ID, "from_codepoint") => string_from_codepoint,
             (ARRAY_ID, "with_size") => array_with_size,
             (BYTEARRAY_ID, "with_size") => ba_with_size,
-            _ => return Value::NIL,
+            _ => return None,
         }
 
         // Method not defined on type
-        _ => return Value::NIL,
+        _ => return None,
     };
 
-    Value::host_fn(f.get())
+    Some(f)
 }
 
 pub fn get_class_id(val: Value) -> ClassId

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -689,6 +689,7 @@ impl ExprBox
 
                     // If the callee is a host function, check the arity
                     Expr::HostFn(host_fn) => {
+                        let host_fn = host_fn.get();
                         if host_fn.num_params() != args.len() {
                             return ParseError::with_pos(
                                 &format!(

--- a/src/value.rs
+++ b/src/value.rs
@@ -149,13 +149,13 @@ impl Value
     pub const FIXNUM_MIN: i64 = -(1 << 61);
 
     #[inline(always)]
-    pub const fn from_raw(bits: u64) -> Value
+    pub const fn from_raw_bits(bits: u64) -> Value
     {
         Value(bits)
     }
 
     #[inline(always)]
-    pub const fn raw(self) -> u64
+    pub const fn raw_bits(self) -> u64
     {
         self.0
     }
@@ -695,7 +695,7 @@ impl Eq for Value {}
 fn slow_eq(a: Value, b: Value) -> bool
 {
     if a.is_string() && b.is_string() {
-        return a.raw() == b.raw() || a.as_str() == b.as_str();
+        return a.raw_bits() == b.raw_bits() || a.as_str() == b.as_str();
     }
 
     if a.is_num() && b.is_num() {
@@ -887,8 +887,8 @@ mod tests
         // Tagged words add directly and order like the integers they hold
         let a = Value::fixnum(7);
         let b = Value::fixnum(-3);
-        assert_eq!(Value::from_raw(a.raw().wrapping_add(b.raw())).as_fixnum(), 4);
-        assert!((a.raw() as i64) > (b.raw() as i64));
+        assert_eq!(Value::from_raw_bits(a.raw_bits().wrapping_add(b.raw_bits())).as_fixnum(), 4);
+        assert!((a.raw_bits() as i64) > (b.raw_bits() as i64));
     }
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -58,7 +58,8 @@
 //! # Assumptions
 //!
 //! - Heap blocks are 8-byte aligned (`alloc::ALIGN`), leaving 3 low bits.
-//! - Pointers fit in 56 bits, so a `&'static HostFn` fits an immediate.
+//! - Host functions are held as a table index, not a pointer, so that the
+//!   whole value fits the immediate range an instruction can carry.
 //! - A heap pointer is never null, so no tagged word collides with an
 //!   immediate or with `nil`.
 //! - Accessors hand out references into the heap. The collector moves
@@ -71,7 +72,8 @@ use crate::ast::{ClassId, FunId};
 use crate::bytearray::ByteArray;
 use crate::closure::Closure;
 use crate::dict::Dict;
-use crate::host::HostFn;
+use crate::host::{HostFn, HostFnId, NUM_HOST_FNS};
+use std::mem::transmute;
 use crate::object::Object;
 use crate::str::Str;
 
@@ -306,22 +308,31 @@ impl Value
         if self.is_class() { Some(self.as_class()) } else { None }
     }
 
+    /// Host functions are held by table index rather than by pointer, so
+    /// that the whole value fits in the immediate range an instruction
+    /// can carry
     #[inline(always)]
-    pub fn host_fn(f: &'static HostFn) -> Value
+    pub fn host_fn(id: HostFnId) -> Value
     {
-        let p = f as *const HostFn as u64;
-        debug_assert!(p >> (64 - IMM_SHIFT) == 0);
-        Value((p << IMM_SHIFT) | IMM_HOSTFN)
+        Value(((id as u64) << IMM_SHIFT) | IMM_HOSTFN)
     }
 
     #[inline(always)]
     pub fn is_host_fn(self) -> bool { self.0 as u8 as u64 == IMM_HOSTFN }
 
     #[inline(always)]
-    pub fn as_host_fn(self) -> &'static HostFn
+    pub fn as_host_fn_id(self) -> HostFnId
     {
         debug_assert!(self.is_host_fn());
-        unsafe { &*((self.0 >> IMM_SHIFT) as *const HostFn) }
+        let idx = (self.0 >> IMM_SHIFT) as u16;
+        debug_assert!((idx as usize) < NUM_HOST_FNS);
+        unsafe { transmute(idx) }
+    }
+
+    #[inline(always)]
+    pub fn as_host_fn(self) -> &'static HostFn
+    {
+        self.as_host_fn_id().get()
     }
 
     #[inline(always)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use crate::dict::Dict;
 #[cfg(feature = "log_gc")]
 use crate::utils::thousands_sep;
-use crate::lexer::SrcPos;
 use crate::ast::{Program, FunId, ClassId, Class};
 use crate::alloc::{Alloc, Tag, HEADER_SIZE, INIT_SIZE, MSG_INIT_SIZE};
 use crate::object::Object;
@@ -13,7 +12,7 @@ use crate::closure::Closure;
 use crate::array::Array;
 use crate::bytearray::ByteArray;
 use crate::codegen::CompiledFun;
-use crate::insns::NameId;
+use crate::insns::{self, NameId, Opcode};
 use crate::gc::{undo_forwarding, Copier, StrTable, UndoLog};
 use crate::host::*;
 use crate::str::Str;
@@ -31,152 +30,48 @@ use std::ops::{Add, Sub, Mul};
 /// the buffer without bound.
 const MSG_BACKLOG_LIMIT: usize = 64 * 1024 * 1024;
 
-/// Instruction opcodes
-/// Note: commonly used upcodes should be in the [0, 127] range (one byte)
-///       less frequently used opcodes can take multiple bytes if necessary.
-#[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug)]
-pub enum Insn
+/// Interpreter instructions, one 64-bit word each. The opcode occupies
+/// the low bits and the operands are packed above it, so an instruction
+/// holds no heap pointers and the collector never walks the code
+pub use crate::insns::Insn;
+
+/// Cache for a field access site. The name is what the site was compiled
+/// for; the class and slot are what it last resolved to
+struct PropCache
 {
-    // Halt execution and produce an error
-    panic { pos: SrcPos },
-
-    // No-op
-    // Not currently emitted by codegen, kept as a building block
-    #[allow(dead_code)]
-    nop,
-
-    // Push an immediate value to the stack. Heap values go through
-    // push_const instead, so that the instruction stream holds no
-    // pointers for the collector to chase
-    push { val: Value },
-
-    // Stack manipulation
-    pop,
-    dup,
-
-    // Not currently emitted by codegen, kept as a building block
-    #[allow(dead_code)]
-    swap,
-
-    // Push the nth-value (indexed from the stack top) on top of the stack
-    // getn 0 is equivalent to dup
-    getn { idx: u16 },
-
-    // Get the function argument at a given index
-    get_arg { idx: u32 },
-
-    // Get the local variable at a given stack slot index
-    // The index is relative to the base of the stack frame
-    get_local { idx: u32 },
-
-    // Set the local variable at a given stack slot index
-    // The index is relative to the base of the stack frame
-    set_local { idx: u32 },
-
-    // Global variable access
-    get_global { idx: u32 },
-    set_global { idx: u32 },
-
-    // Arithmetic
-    add,
-    sub,
-    mul,
-    div,
-    div_int,
-    modulo,
-
-    // Add an int64 constant
-    add_i64 { val: i64 },
-
-    // Bitwise operations
-    bit_and,
-    bit_or,
-    bit_xor,
-    lshift,
-    rshift,
-
-    // Comparisons
-    lt,
-    le,
-    gt,
-    ge,
-    eq,
-    ne,
-
-    // Logical negation
-    not,
-
-    // Closure operations
-    clos_new { fun_id: FunId, num_slots: u32 },
-    clos_set { idx: u32 },
-    clos_get { idx: u32 },
-
-    // Mutable cell operations
-    cell_new,
-    cell_set,
-    cell_get,
-
-    // Create class instance
-    new { class_id: ClassId, argc: u8 },
-
-    // Create a class instance with a known number of slots and constructor
-    new_known_ctor { class_id: ClassId, argc: u8, num_slots: u16, ctor_pc: u32, fun_id: FunId, num_locals: u16 },
-
-    // Check if instance of class
-    instanceof { class_id: ClassId },
-
-    // Get/set field
-    get_field { name: NameId, class_id: ClassId, slot_idx: u32 },
-    set_field { name: NameId, class_id: ClassId, slot_idx: u32 },
-
-    // Get/set indexed element
-    get_index,
-    set_index,
-
-    // Create a new dictionary
-    dict_new,
-
-    // Array operations
-    arr_new { capacity: u32 },
-    arr_push,
-
-    // Clone a bytearray
-    ba_clone,
-
-    // Jump if true/false
-    if_true { target_ofs: i32 },
-    if_false { target_ofs: i32 },
-
-    // Unconditional jump
-    jump { target_ofs: i32 },
-
-    // Call a function using the call stack
-    // call (arg0, arg1, ..., argN)
-    call { argc: u8 },
-
-    // Call a known function using its function id
-    call_direct { fun_id: FunId, argc: u8 },
-
-    // Call a known function by directly jumping to its entry point
-    call_pc { entry_pc: u32, fun_id: FunId, num_locals: u16, argc: u8 },
-
-    // Call a method on an object
-    // call_method (self, arg0, ..., argN)
-    call_method { name: NameId, argc: u8 },
-
-    // Call a method with a previously known pc
-    call_method_pc { name: NameId, argc: u8, class_id: ClassId, entry_pc: u32, fun_id: FunId, num_locals: u16 },
-
-    // Call a host method on a primitive, guarded on the type tag
-    call_method_host { name: NameId, argc: u8, type_tag: Type, host_fn: HostFnId },
-
-    // Return
-    ret,
-
-    // Push a heap constant from the actor's constant pool
-    push_const { idx: u32 },
+    name: NameId,
+    class_id: ClassId,
+    slot_idx: u32,
 }
+
+/// Cache for a call site whose callee is not statically known.
+///
+/// A dynamic call guards on the function value it last resolved to, a
+/// method call on the class it last looked the name up on, and a host
+/// method on the type tag in the instruction. A site that has resolved
+/// records everything the frame needs, so the call itself is a push and
+/// a jump
+#[derive(Default)]
+struct CallCache
+{
+    name: NameId,
+
+    // Class the site last looked the method up on, which is what a
+    // method call guards against
+    class_id: ClassId,
+
+    // Callee the site resolved to
+    fun_id: FunId,
+    entry_pc: u32,
+    frame_size: u16,
+
+    // Set for a constructor site, which allocates before it calls
+    num_slots: u16,
+
+    // Set for a host method site, which the type tag guards
+    host_fn: HostFnId,
+}
+
 
 // This error macro is to be used inside host functions
 #[macro_export]
@@ -211,11 +106,13 @@ struct StackFrame
     // Function currently executing
     fun: Value,
 
-    // Argument count (number of args supplied)
-    argc: u8,
-
     // Previous base pointer at the time of call
     prev_bp: usize,
+
+    // How far the stack reached in the caller's frame, which is what a
+    // return restores. The callee's frame starts inside the caller's, so
+    // this is what tells the two apart
+    prev_top: usize,
 
     // Return address
     ret_addr: usize,
@@ -285,6 +182,12 @@ pub struct Actor
     names: Vec<String>,
     name_ids: HashMap<String, NameId>,
     name_strs: Vec<Value>,
+
+    // Inline caches, one entry per site that can resolve to more than one
+    // thing. Holding the payload out of line is what keeps an instruction
+    // within a single word
+    prop_caches: Vec<PropCache>,
+    call_caches: Vec<CallCache>,
 }
 
 /// Why an integer operation produced no result
@@ -401,6 +304,8 @@ impl Actor
             names: Vec::default(),
             name_ids: HashMap::default(),
             name_strs: Vec::default(),
+            prop_caches: Vec::default(),
+            call_caches: Vec::default(),
         }
     }
 
@@ -750,8 +655,10 @@ impl Actor
     /// Kept out of line so that the interpreter loop carries only the
     /// cached case
     #[inline(never)]
-    fn get_field_slow(&mut self, obj: Value, name: NameId, insn_pc: usize) -> Result<Value, String>
+    fn get_field_slow(&mut self, obj: Value, cache: u32) -> Result<Value, String>
     {
+        let name = self.prop_caches[cache as usize].name;
+
         if !obj.is_heap() {
             return Err(format!("get_field on non-object value {:?}", obj));
         }
@@ -777,11 +684,9 @@ impl Actor
                 };
 
                 // Update the cache
-                self.insns[insn_pc] = Insn::get_field {
-                    name,
-                    class_id: o.class_id,
-                    slot_idx: slot_idx as u32,
-                };
+                let entry = &mut self.prop_caches[cache as usize];
+                entry.class_id = o.class_id;
+                entry.slot_idx = slot_idx as u32;
 
                 let val = o.get(slot_idx);
 
@@ -829,9 +734,11 @@ impl Actor
     /// Resolve a field write the cached path did not handle: a dict, or
     /// an object of a class this site has not seen
     #[inline(never)]
-    fn set_field_slow(&mut self, mut obj: Value, mut val: Value, name: NameId, insn_pc: usize)
+    fn set_field_slow(&mut self, mut obj: Value, mut val: Value, cache: u32)
         -> Result<(), String>
     {
+        let name = self.prop_caches[cache as usize].name;
+
         if let Some(o) = obj.to_obj() {
             let slot_idx = match self.get_slot_idx_of(o.class_id, name) {
                 Some(slot_idx) => slot_idx,
@@ -848,11 +755,9 @@ impl Actor
             };
 
             // Update the cache
-            self.insns[insn_pc] = Insn::set_field {
-                name,
-                class_id: o.class_id,
-                slot_idx: slot_idx as u32,
-            };
+            let entry = &mut self.prop_caches[cache as usize];
+            entry.class_id = o.class_id;
+            entry.slot_idx = slot_idx as u32;
 
             o.set(slot_idx, val);
             return Ok(());
@@ -872,12 +777,47 @@ impl Actor
         Err("set_field on non-object/dict value".to_string())
     }
 
-    /// Add a heap constant to this actor's pool and return its index.
-    /// The pool is a GC root, so a constant is safe to hold from the
-    /// moment it lands here
+    /// Create a cache entry for a field access site
+    pub fn new_prop_cache(&mut self, name: &str) -> u32
+    {
+        let name = self.intern_name(name);
+
+        // The class id no real object has, so a fresh site always misses
+        self.prop_caches.push(PropCache {
+            name,
+            class_id: ClassId::default(),
+            slot_idx: 0,
+        });
+
+        (self.prop_caches.len() - 1) as u32
+    }
+
+    /// Create a cache entry for a call site
+    pub fn new_call_cache(&mut self, name: &str) -> u32
+    {
+        let name = if name.is_empty() { 0 } else { self.intern_name(name) };
+
+        self.new_call_cache_entry(CallCache {
+            name,
+            ..CallCache::default()
+        })
+    }
+
+    /// Add a call cache entry and return its index. A site that is
+    /// rewritten into a cached form allocates its entry the first time it
+    /// runs, which happens once
+    fn new_call_cache_entry(&mut self, cache: CallCache) -> u32
+    {
+        self.call_caches.push(cache);
+        (self.call_caches.len() - 1) as u32
+    }
+
+    /// Add a constant to this actor's pool and return its index. The
+    /// pool holds the heap constants the code refers to, along with the
+    /// immediates too wide to sit in an instruction. It is a GC root, so
+    /// a constant is safe to hold from the moment it lands here
     pub fn push_const(&mut self, val: Value) -> u32
     {
-        debug_assert!(val.is_heap());
         self.consts.push(val);
         (self.consts.len() - 1) as u32
     }
@@ -1227,14 +1167,13 @@ impl Actor
     /// Call a host function
     /// Kept out of line so its arity dispatch doesn't bloat the interpreter loop
     #[inline(never)]
-    fn call_host(&mut self, host_fn: &HostFn, argc: usize) -> Result<(), String>
+    /// Call a host function. Its arguments sit in consecutive registers
+    /// starting at `base`, and the value it returns is written back over
+    /// the first of them, which is where a call leaves its result
+    fn call_host(&mut self, host_fn: &HostFn, base: usize, argc: usize) -> Result<(), String>
     {
-        macro_rules! pop {
-            () => { self.stack.pop().unwrap() }
-        }
-
-        macro_rules! push {
-            ($val: expr) => { self.stack.push($val) }
+        macro_rules! arg {
+            ($idx: expr) => { self.stack[base + $idx] }
         }
 
         if host_fn.num_params() != argc {
@@ -1246,6 +1185,8 @@ impl Actor
             ));
         }
 
+        debug_assert!(base + argc <= self.stack.len());
+
         let result = match host_fn.f
         {
             FnPtr::Fn0(fun) => {
@@ -1253,55 +1194,41 @@ impl Actor
             }
 
             FnPtr::Fn1(fun) => {
-                let a0 = pop!();
+                let a0 = arg!(0);
                 fun(self, a0)
             }
 
             FnPtr::Fn2(fun) => {
-                let a1 = pop!();
-                let a0 = pop!();
+                let (a0, a1) = (arg!(0), arg!(1));
                 fun(self, a0, a1)
             }
 
             FnPtr::Fn3(fun) => {
-                let a2 = pop!();
-                let a1 = pop!();
-                let a0 = pop!();
+                let (a0, a1, a2) = (arg!(0), arg!(1), arg!(2));
                 fun(self, a0, a1, a2)
             }
 
             FnPtr::Fn4(fun) => {
-                let a3 = pop!();
-                let a2 = pop!();
-                let a1 = pop!();
-                let a0 = pop!();
+                let (a0, a1, a2, a3) = (arg!(0), arg!(1), arg!(2), arg!(3));
                 fun(self, a0, a1, a2, a3)
             }
 
             FnPtr::Fn5(fun) => {
-                let a4 = pop!();
-                let a3 = pop!();
-                let a2 = pop!();
-                let a1 = pop!();
-                let a0 = pop!();
+                let (a0, a1, a2, a3, a4) = (arg!(0), arg!(1), arg!(2), arg!(3), arg!(4));
                 fun(self, a0, a1, a2, a3, a4)
             }
 
             FnPtr::Fn8(fun) => {
-                let a7 = pop!();
-                let a6 = pop!();
-                let a5 = pop!();
-                let a4 = pop!();
-                let a3 = pop!();
-                let a2 = pop!();
-                let a1 = pop!();
-                let a0 = pop!();
+                let (a0, a1, a2, a3) = (arg!(0), arg!(1), arg!(2), arg!(3));
+                let (a4, a5, a6, a7) = (arg!(4), arg!(5), arg!(6), arg!(7));
                 fun(self, a0, a1, a2, a3, a4, a5, a6, a7)
             }
         };
 
         match result {
-            Ok(v) => { push!(v); Ok(()) },
+            // A host function can collect, so the result is written back
+            // by index rather than through a reference taken beforehand
+            Ok(v) => { self.stack[base] = v; Ok(()) },
             Err(e) => Err(format!("error during call to host function `{}`:\n{}", host_fn.name, e)),
         }
     }
@@ -1371,8 +1298,9 @@ impl Actor
             self.report_error("", &format!("expected function value but got {:?}", fun));
         }
 
-        // Push the arguments on the stack. Compiling below can collect,
-        // and the stack is where the collector looks for them.
+        // The arguments become the first registers of the frame.
+        // Compiling below can collect, and the stack is where the
+        // collector looks for them.
         for arg in args {
             self.stack.push(*arg);
         }
@@ -1393,41 +1321,40 @@ impl Actor
         // Push a new stack frame
         self.frames.push(StackFrame {
             fun,
-            argc: args.len().try_into().unwrap(),
             prev_bp: usize::MAX,
+            prev_top: 0,
             ret_addr: usize::MAX,
         });
 
-        // The base pointer will point at the first local
-        let mut bp = self.stack.len();
+        // The frame of the outermost call starts at the bottom of the stack
+        let mut bp = 0;
 
-        // Allocate stack slots for the local variables
-        self.stack.resize(self.stack.len() + fun_entry.num_locals, Value::NIL);
+        // Every register the frame covers has to hold a value the
+        // collector can look at, so the ones past the arguments start nil
+        self.stack.resize(fun_entry.frame_size, Value::NIL);
 
-        macro_rules! pop {
-            () => { self.stack.pop().unwrap() }
+        // Read a register of the current frame. Codegen sizes every frame
+        // to the registers its function uses, so the index is in bounds.
+        macro_rules! get_reg {
+            ($reg: expr) => {{
+                let idx = bp + ($reg as usize);
+                debug_assert!(idx < self.stack.len());
+                unsafe { *self.stack.get_unchecked(idx) }
+            }}
         }
 
-        macro_rules! push {
-            ($val: expr) => { self.stack.push($val) }
+        // Write a register of the current frame
+        macro_rules! set_reg {
+            ($reg: expr, $val: expr) => {{
+                let idx = bp + ($reg as usize);
+                let val = $val;
+                debug_assert!(idx < self.stack.len());
+                unsafe { *self.stack.get_unchecked_mut(idx) = val; }
+            }}
         }
 
-        macro_rules! push_bool {
-            ($b: expr) => { push!(Value::bool_val($b)) }
-        }
-
-        // Fast path for two inline doubles: decode, apply and re-encode.
-        // Falls through when either operand is not one, or when the
-        // result is a double that has to be boxed.
-        macro_rules! flonum_op {
-            ($v0: expr, $v1: expr, $op: tt) => {
-                if $v0.is_flonum() && $v1.is_flonum() {
-                    if let Some(r) = Value::try_flonum($v0.as_flonum() $op $v1.as_flonum()) {
-                        push!(r);
-                        continue;
-                    }
-                }
-            }
+        macro_rules! set_reg_bool {
+            ($reg: expr, $b: expr) => { set_reg!($reg, Value::bool_val($b)) }
         }
 
         // Take the result of a slow path, reporting a type error the
@@ -1446,15 +1373,16 @@ impl Actor
         // and sub want, and `as_fixnum` drops it, so that a product comes
         // out tagged exactly once.
         macro_rules! arith_insn {
-            ($insn: literal, $checked_op: ident, $rhs: ident, $float_op: path, $slow_path: ident) => {{
-                let v1 = pop!();
-                let v0 = pop!();
+            ($insn_word: expr, $insn: literal, $opnds: ident, $checked_op: ident, $rhs: ident, $float_op: path, $slow_path: ident) => {{
+                let opnds = insns::$opnds::decode($insn_word);
+                let v0 = get_reg!(opnds.a);
+                let v1 = get_reg!(opnds.b);
 
                 // A 64-bit overflow is exactly the case where the result
                 // no longer fits in a fixnum
                 if v0.is_fixnum() && v1.is_fixnum() {
-                    if let Some(r) = (v0.raw() as i64).$checked_op(v1.$rhs() as i64) {
-                        push!(Value::from_raw(r as u64));
+                    if let Some(r) = (v0.raw_bits() as i64).$checked_op(v1.$rhs() as i64) {
+                        set_reg!(opnds.dst, Value::from_raw_bits(r as u64));
                         continue;
                     }
                 }
@@ -1463,79 +1391,142 @@ impl Actor
                     let f = $float_op(v0.as_flonum(), v1.as_flonum());
 
                     if let Some(r) = Value::try_flonum(f) {
-                        push!(r);
+                        set_reg!(opnds.dst, r);
                         continue;
                     }
                 }
 
                 let r = slow!($insn, self.$slow_path(v0, v1));
-                push!(r);
+                set_reg!(opnds.dst, r);
+            }}
+        }
+
+        // Arithmetic against a fixnum immediate
+        macro_rules! arith_imm_insn {
+            ($insn_word: expr, $insn: literal, $opnds: ident, $checked_op: ident, $rhs: ident, $slow_path: ident) => {{
+                let opnds = insns::$opnds::decode($insn_word);
+                let v0 = get_reg!(opnds.a);
+
+                // The immediate always fits a fixnum, so the tagged words
+                // can be combined directly
+                let cst = Value::fixnum(opnds.imm as i64);
+
+                if v0.is_fixnum() {
+                    if let Some(r) = (v0.raw_bits() as i64).$checked_op(cst.$rhs() as i64) {
+                        set_reg!(opnds.dst, Value::from_raw_bits(r as u64));
+                        continue;
+                    }
+                }
+
+                let r = slow!($insn, self.$slow_path(v0, cst));
+                set_reg!(opnds.dst, r);
             }}
         }
 
         // Bitwise ops. Fixnum tags are zero, so the op keeps them that
         // way and the result needs no retagging.
         macro_rules! bitop_insn {
-            ($insn: literal, $op: tt, $slow_path: ident) => {{
-                let v1 = pop!();
-                let v0 = pop!();
+            ($insn_word: expr, $insn: literal, $opnds: ident, $op: tt, $slow_path: ident) => {{
+                let opnds = insns::$opnds::decode($insn_word);
+                let v0 = get_reg!(opnds.a);
+                let v1 = get_reg!(opnds.b);
 
                 if v0.is_fixnum() && v1.is_fixnum() {
-                    push!(Value::from_raw(v0.raw() $op v1.raw()));
+                    set_reg!(opnds.dst, Value::from_raw_bits(v0.raw_bits() $op v1.raw_bits()));
                     continue;
                 }
 
                 let r = slow!($insn, self.$slow_path(v0, v1));
-                push!(r);
+                set_reg!(opnds.dst, r);
             }}
         }
 
-        // Comparisons. Tagged fixnums order like the integers they hold,
-        // and inline doubles are decoded and compared directly.
-        macro_rules! cmp_insn {
-            ($insn: literal, $op: tt, $slow_path: ident) => {{
-                let v1 = pop!();
-                let v0 = pop!();
+        // Compare and branch. Tagged fixnums order like the integers they
+        // hold, and inline doubles are decoded and compared directly.
+        macro_rules! cmp_branch {
+            ($insn_word: expr, $insn: literal, $opnds: ident, $op: tt, $slow_path: ident) => {{
+                let opnds = insns::$opnds::decode($insn_word);
+                let v0 = get_reg!(opnds.a);
+                let v1 = get_reg!(opnds.b);
 
-                if v0.is_fixnum() && v1.is_fixnum() {
-                    push_bool!((v0.raw() as i64) $op (v1.raw() as i64));
+                let taken = if v0.is_fixnum() && v1.is_fixnum() {
+                    (v0.raw_bits() as i64) $op (v1.raw_bits() as i64)
                 } else if v0.is_flonum() && v1.is_flonum() {
-                    push_bool!(v0.as_flonum() $op v1.as_flonum());
+                    v0.as_flonum() $op v1.as_flonum()
                 } else {
-                    push_bool!(slow!($insn, $slow_path(v0, v1)));
+                    slow!($insn, $slow_path(v0, v1))
+                };
+
+                if taken {
+                    pc = ((pc as i64) + (opnds.disp as i64)) as usize;
                 }
             }}
         }
 
-        // Set up a new frame for a function call
-        macro_rules! call_fun {
-            ($fun: expr, $argc: expr) => {{
-                if $argc as usize > self.stack.len() - bp {
-                    error!("not enough call arguments on stack");
+        // Set up a new frame and jump into a callee. The callee's frame
+        // starts at the caller's `start_reg`, which is where its
+        // arguments already sit and where its return value will land.
+        macro_rules! push_frame {
+            ($fun_val: expr, $start_reg: expr, $entry_pc: expr, $frame_size: expr) => {{
+                let new_bp = bp + ($start_reg as usize);
+
+                self.frames.push(StackFrame {
+                    fun: $fun_val,
+                    prev_bp: bp,
+                    prev_top: self.stack.len(),
+                    ret_addr: pc,
+                });
+
+                bp = new_bp;
+                pc = $entry_pc as usize;
+
+                // Registers the callee has not written yet still have to
+                // hold something the collector can look at
+                self.stack.resize(bp + ($frame_size as usize), Value::NIL);
+            }}
+        }
+
+        // Hand a value back to the caller and drop this frame. The
+        // value goes to the callee's frame base, which is the register
+        // the caller set the call up in
+        macro_rules! do_return {
+            ($val: expr) => {{
+                let ret_val = $val;
+
+                // If this is a top-level return
+                if self.frames.len() == 1 {
+                    self.stack.clear();
+                    self.frames.clear();
+                    return ret_val;
                 }
 
-                // The callee can be a closure, and compiling below can
-                // collect, so it is held where it can be rooted
-                let mut fun_val = $fun;
+                let frame = self.frames.pop().unwrap();
+                self.stack[bp] = ret_val;
+
+                // Restoring the caller's frame drops whatever the callee
+                // used above it, and refills what it left short
+                self.stack.resize(frame.prev_top, Value::NIL);
+
+                bp = frame.prev_bp;
+                pc = frame.ret_addr;
+            }}
+        }
+
+        // Resolve a callee that is not statically known, checking its
+        // argument count. This can compile the callee and therefore
+        // collect, so the callee is held where the collector can see it.
+        macro_rules! resolve_callee {
+            ($fun_val: expr, $argc: expr) => {{
+                let mut fun_val = $fun_val;
 
                 let fun_id = match fun_val.to_fun_id() {
                     Some(id) => id,
-
-                    None => match fun_val.to_host_fn() {
-                        Some(f) => {
-                            match self.call_host(f, $argc.into()) {
-                                Err(msg) => error!("{}", msg),
-                                Ok(()) => continue
-                            }
-                        }
-                        None => error!("call to non-function value: `{:?}`", fun_val)
-                    }
+                    None => error!("call to non-function value: `{:?}`", fun_val)
                 };
 
-                // Get a compiled address for this function
-                let fun_entry = self.get_compiled_fun(&mut fun_val);
+                let entry = self.get_compiled_fun(&mut fun_val);
 
-                if $argc as usize != fun_entry.num_params {
+                if ($argc as usize) != entry.num_params {
                     let vm = self.vm.lock().unwrap();
                     let fun = &vm.prog.funs[&fun_id];
                     error!(
@@ -1543,25 +1534,11 @@ impl Actor
                         fun.name,
                         fun.pos,
                         $argc,
-                        fun_entry.num_params
+                        entry.num_params
                     );
                 }
 
-                self.frames.push(StackFrame {
-                    argc: $argc,
-                    fun: fun_val,
-                    prev_bp: bp,
-                    ret_addr: pc,
-                });
-
-                // The base pointer will point at the first local
-                bp = self.stack.len();
-                pc = fun_entry.entry_pc;
-
-                // Allocate stack slots for the local variables
-                self.stack.resize(self.stack.len() + fun_entry.num_locals, Value::NIL);
-
-                fun_entry
+                (fun_val, fun_id, entry)
             }}
         }
 
@@ -1583,99 +1560,49 @@ impl Actor
 
         loop
         {
-            // Every compiled function ends with a ret instruction, so
+            // Every compiled function ends with a return instruction, so
             // execution can never run past the end of the insn stream.
             // That makes the load in bounds and keeps the increment below
             // the length, so neither needs to be checked here.
             debug_assert!(pc < self.insns.len());
             let insn = unsafe { *self.insns.get_unchecked(pc) };
+            let this_pc = pc;
             pc = unsafe { pc.unchecked_add(1) };
-            //println!("executing {:?}", insn);
-            //println!("stack size: {}, executing {:?}", self.stack.len(), insn);
 
-            match insn {
-                Insn::nop => {},
+            match insn.opcode() {
+                Opcode::nop => {},
 
-                Insn::panic { pos } => {
-                    error!("explicit panic at: {}", pos);
+                Opcode::breakpoint => {},
+
+                Opcode::panic => {
+                    let opnds = insns::panic::decode(insn);
+                    error!(
+                        "explicit panic at: {}@{}:{}",
+                        crate::lexer::name_from_id(opnds.file_id as u32),
+                        opnds.line_no,
+                        opnds.col_no,
+                    );
                 }
 
-                Insn::push { val } => {
-                   debug_assert!(!val.is_heap());
-                   self.stack.push(val);
+                Opcode::load_imm32 => {
+                    let opnds = insns::load_imm32::decode(insn);
+                    set_reg!(opnds.dst, Value::from_raw_bits(opnds.imm as i64 as u64));
                 }
 
-                Insn::push_const { idx } => {
-                    let val = self.consts[idx as usize];
-                    self.stack.push(val);
+                Opcode::load_const => {
+                    let opnds = insns::load_const::decode(insn);
+                    let val = self.consts[opnds.slot as usize];
+                    set_reg!(opnds.dst, val);
                 }
 
-                Insn::dup => {
-                    let val = pop!();
-                    push!(val);
-                    push!(val);
+                Opcode::mov => {
+                    let opnds = insns::mov::decode(insn);
+                    set_reg!(opnds.dst, get_reg!(opnds.src));
                 }
 
-                Insn::pop => {
-                    pop!();
-                }
-
-                Insn::swap => {
-                    let a = pop!();
-                    let b = pop!();
-                    push!(a);
-                    push!(b);
-                }
-
-                Insn::getn { idx } => {
-                    let idx = idx as usize;
-                    let val = self.stack[self.stack.len() - (1 + idx)];
-                    push!(val);
-                }
-
-                Insn::get_arg { idx } => {
-                    let argc = self.frames[self.frames.len() - 1].argc as usize;
-                    let idx = idx as usize;
-
-                    if idx >= argc {
-                        error!(
-                            "invalid index in get_arg, idx={}, argc={}, stack depth: {}",
-                            idx,
-                            argc,
-                            self.frames.len()
-                        );
-                    }
-
-                    // Last argument is at bp - 1 (if there are arguments)
-                    let stack_idx = (bp - argc) + idx;
-                    let arg_val = self.stack[stack_idx];
-                    push!(arg_val);
-                    //println!("arg_val={:?}", arg_val);
-                }
-
-                Insn::get_local { idx } => {
-                    let idx = idx as usize;
-
-                    if bp + idx >= self.stack.len() {
-                        error!("invalid index {} in get_local", idx);
-                    }
-
-                    push!(self.stack[bp + idx]);
-                }
-
-                Insn::set_local { idx } => {
-                    let idx = idx as usize;
-                    let val = pop!();
-
-                    if bp + idx >= self.stack.len() {
-                        error!("invalid index in set_local");
-                    }
-
-                    self.stack[bp + idx] = val;
-                }
-
-                Insn::get_global { idx } => {
-                    let idx = idx as usize;
+                Opcode::get_global => {
+                    let opnds = insns::get_global::decode(insn);
+                    let idx = opnds.idx as usize;
 
                     if idx >= self.globals.len() {
                         error!("get_global", "invalid global index {}", idx);
@@ -1687,107 +1614,113 @@ impl Actor
                         error!("get_global", "attempting to read uninitialized global");
                     }
 
-                    push!(val);
+                    set_reg!(opnds.dst, val);
                 }
 
-                Insn::set_global { idx } => {
-                    let idx = idx as usize;
-                    let val = pop!();
+                Opcode::set_global => {
+                    let opnds = insns::set_global::decode(insn);
+                    let idx = opnds.idx as usize;
 
                     if idx >= self.globals.len() {
                         error!("set_global", "invalid global index {}", idx);
                     }
 
-                    self.globals[idx] = val;
+                    self.globals[idx] = get_reg!(opnds.src);
                 }
 
-                Insn::add => arith_insn!("add", checked_add, raw, f64::add, add_slow),
-                Insn::sub => arith_insn!("sub", checked_sub, raw, f64::sub, sub_slow),
-                Insn::mul => arith_insn!("mul", checked_mul, as_fixnum, f64::mul, mul_slow),
+                Opcode::add => arith_insn!(insn, "add", add, checked_add, raw_bits, f64::add, add_slow),
+                Opcode::sub => arith_insn!(insn, "sub", sub, checked_sub, raw_bits, f64::sub, sub_slow),
+                Opcode::mul => arith_insn!(insn, "mul", mul, checked_mul, as_fixnum, f64::mul, mul_slow),
+
+                Opcode::add_imm16 => arith_imm_insn!(insn, "add", add_imm16, checked_add, raw_bits, add_slow),
+                Opcode::sub_imm16 => arith_imm_insn!(insn, "sub", sub_imm16, checked_sub, raw_bits, sub_slow),
+                Opcode::mul_imm16 => arith_imm_insn!(insn, "mul", mul_imm16, checked_mul, as_fixnum, mul_slow),
 
                 // Division always produces a float
                 // Division by zero produces an infinity (this is intentional)
-                Insn::div => {
-                    let v1 = pop!();
-                    let v0 = pop!();
+                Opcode::div => {
+                    let opnds = insns::div::decode(insn);
+                    let v0 = get_reg!(opnds.a);
+                    let v1 = get_reg!(opnds.b);
 
-                    flonum_op!(v0, v1, /);
+                    if v0.is_flonum() && v1.is_flonum() {
+                        if let Some(r) = Value::try_flonum(v0.as_flonum() / v1.as_flonum()) {
+                            set_reg!(opnds.dst, r);
+                            continue;
+                        }
+                    }
 
                     let r = slow!("div", self.div_num(v0, v1));
-                    push!(r);
+                    set_reg!(opnds.dst, r);
                 }
 
                 // Integer division
                 // Division by zero will cause a panic (this is intentional)
-                Insn::div_int => {
-                    let v1 = pop!();
-                    let v0 = pop!();
+                Opcode::div_int => {
+                    let opnds = insns::div_int::decode(insn);
+                    let v0 = get_reg!(opnds.a);
+                    let v1 = get_reg!(opnds.b);
 
                     // Dividing shrinks the magnitude, so the quotient
                     // fits unless it is the one case that overflows
                     if v0.is_fixnum() && v1.is_fixnum() {
                         if let Some(q) = v0.as_fixnum().checked_div(v1.as_fixnum()) {
                             if let Some(r) = Value::try_fixnum(q) {
-                                push!(r);
+                                set_reg!(opnds.dst, r);
                                 continue;
                             }
                         }
                     }
 
                     let r = slow!("div_int", self.div_int_slow(v0, v1));
-                    push!(r);
+                    set_reg!(opnds.dst, r);
                 }
 
                 // Division by zero will cause a panic (this is intentional)
-                Insn::modulo => {
-                    let v1 = pop!();
-                    let v0 = pop!();
+                Opcode::modulo => {
+                    let opnds = insns::modulo::decode(insn);
+                    let v0 = get_reg!(opnds.a);
+                    let v1 = get_reg!(opnds.b);
 
                     // A remainder is smaller than its divisor, so it
                     // always fits back into a fixnum
                     if v0.is_fixnum() && v1.is_fixnum() {
                         if let Some(rem) = v0.as_fixnum().checked_rem(v1.as_fixnum()) {
-                            push!(Value::fixnum(rem));
+                            set_reg!(opnds.dst, Value::fixnum(rem));
                             continue;
                         }
                     }
 
-                    flonum_op!(v0, v1, %);
+                    if v0.is_flonum() && v1.is_flonum() {
+                        if let Some(r) = Value::try_flonum(v0.as_flonum() % v1.as_flonum()) {
+                            set_reg!(opnds.dst, r);
+                            continue;
+                        }
+                    }
 
                     let r = slow!("modulo", self.modulo_slow(v0, v1));
-                    push!(r);
+                    set_reg!(opnds.dst, r);
                 }
 
-                // Add a constant int64 value
-                Insn::add_i64 { val } => {
-                    // The constant fits a fixnum, so the tagged words add
-                    let cst = Value::fixnum(val);
+                Opcode::bit_or => bitop_insn!(insn, "bit_or", bit_or, |, bit_or_slow),
+                Opcode::bit_and => bitop_insn!(insn, "bit_and", bit_and, &, bit_and_slow),
+                Opcode::bit_xor => bitop_insn!(insn, "bit_xor", bit_xor, ^, bit_xor_slow),
 
-                    let top = match self.stack.last_mut() {
-                        Some(top) => top,
-                        None => error!("add_i64", "stack is empty"),
-                    };
+                Opcode::bit_not => {
+                    let opnds = insns::bit_not::decode(insn);
+                    let v0 = get_reg!(opnds.src);
 
-                    if top.is_fixnum() {
-                        if let Some(sum) = (top.raw() as i64).checked_add(cst.raw() as i64) {
-                            *top = Value::from_raw(sum as u64);
-                            continue;
-                        }
+                    match v0.to_i64() {
+                        Some(v) => { let r = self.int64(!v); set_reg!(opnds.dst, r); }
+                        None => error!("bit_not", "unsupported type in bitwise not {:?}", v0)
                     }
-
-                    let v0 = pop!();
-                    let r = slow!("add_i64", self.add_slow(v0, cst));
-                    push!(r);
                 }
-
-                Insn::bit_or => bitop_insn!("bit_or", |, bit_or_slow),
-                Insn::bit_and => bitop_insn!("bit_and", &, bit_and_slow),
-                Insn::bit_xor => bitop_insn!("bit_xor", ^, bit_xor_slow),
 
                 // Integer left shift
-                Insn::lshift => {
-                    let v1 = pop!();
-                    let v0 = pop!();
+                Opcode::lshift => {
+                    let opnds = insns::lshift::decode(insn);
+                    let v0 = get_reg!(opnds.a);
+                    let v1 = get_reg!(opnds.b);
 
                     // The shift can push bits out of fixnum range, so the
                     // result has to be checked rather than retagged
@@ -1796,20 +1729,21 @@ impl Actor
 
                         if shift >= 0 && shift < 62 {
                             if let Some(r) = Value::try_fixnum(v0.as_fixnum() << shift) {
-                                push!(r);
+                                set_reg!(opnds.dst, r);
                                 continue;
                             }
                         }
                     }
 
                     let r = slow!("lshift", self.lshift_slow(v0, v1));
-                    push!(r);
+                    set_reg!(opnds.dst, r);
                 }
 
                 // Integer right shift
-                Insn::rshift => {
-                    let v1 = pop!();
-                    let v0 = pop!();
+                Opcode::rshift => {
+                    let opnds = insns::rshift::decode(insn);
+                    let v0 = get_reg!(opnds.a);
+                    let v1 = get_reg!(opnds.b);
 
                     // Shifting a fixnum right keeps it in range, so only
                     // the bits the tag occupies have to be cleared
@@ -1817,72 +1751,57 @@ impl Actor
                         let shift = v1.as_fixnum();
 
                         if shift >= 0 && shift < 62 {
-                            push!(Value::fixnum(v0.as_fixnum() >> shift));
+                            set_reg!(opnds.dst, Value::fixnum(v0.as_fixnum() >> shift));
                             continue;
                         }
                     }
 
                     let r = slow!("rshift", self.rshift_slow(v0, v1));
-                    push!(r);
-                }
-
-                Insn::lt => cmp_insn!("lt", <, cmp_lt),
-                Insn::le => cmp_insn!("le", <=, cmp_le),
-                Insn::gt => cmp_insn!("gt", >, cmp_gt),
-                Insn::ge => cmp_insn!("ge", >=, cmp_ge),
-
-                Insn::eq => {
-                    let v1 = pop!();
-                    let v0 = pop!();
-                    push_bool!(v0 == v1);
-                }
-
-                Insn::ne => {
-                    let v1 = pop!();
-                    let v0 = pop!();
-                    push_bool!(v0 != v1);
+                    set_reg!(opnds.dst, r);
                 }
 
                 // Logical negation
-                Insn::not => {
-                    let v0 = pop!();
+                Opcode::not => {
+                    let opnds = insns::not::decode(insn);
+                    let v0 = get_reg!(opnds.src);
 
                     match v0.to_bool() {
-                        Some(b) => push_bool!(!b),
+                        Some(b) => set_reg_bool!(opnds.dst, !b),
                         None => error!("not", "unsupported type in logical not {:?}", v0)
                     }
                 }
 
                 // Create a new closure
-                Insn::clos_new { fun_id, num_slots } => {
-                    let num_slots = num_slots as usize;
+                Opcode::clos_new => {
+                    let opnds = insns::clos_new::decode(insn);
+                    let num_slots = opnds.num_slots as usize;
 
-                     self.gc_check(
-                        Closure::alloc_size(num_slots),
-                        &mut [],
-                    );
+                    self.gc_check(Closure::alloc_size(num_slots), &mut []);
 
+                    let fun_id = FunId::from(opnds.fun_id as usize);
                     let clos = Closure::new(fun_id, num_slots, &mut self.alloc);
-                    push!(clos);
+                    set_reg!(opnds.dst, clos);
                 }
 
                 // Set a closure slot
-                Insn::clos_set { idx } => {
-                    let val = pop!();
-                    let clos = pop!();
+                Opcode::clos_set => {
+                    let opnds = insns::clos_set::decode(insn);
+                    let clos = get_reg!(opnds.clos);
+                    let val = get_reg!(opnds.src);
 
                     match clos.to_clos() {
-                        Some(clos) => clos.set(idx as usize, val),
+                        Some(clos) => clos.set(opnds.idx as usize, val),
                         None => error!("clos_set", "expected closure")
                     }
                 }
 
                 // Get a closure slot for the function currently executing
-                Insn::clos_get { idx } => {
+                Opcode::clos_get => {
+                    let opnds = insns::clos_get::decode(insn);
                     let fun = self.frames[self.frames.len() - 1].fun;
 
                     let val = match fun.to_clos() {
-                        Some(clos) => clos.get(idx as usize),
+                        Some(clos) => clos.get(opnds.idx as usize),
                         None => error!("clos_get", "not a closure")
                     };
 
@@ -1890,24 +1809,24 @@ impl Actor
                         error!("clos_get", "executing uninitialized closure");
                     }
 
-                    push!(val);
+                    set_reg!(opnds.dst, val);
                 }
 
                 // Create a new mutable cell
-                Insn::cell_new => {
-                     self.gc_check(
-                        HEADER_SIZE + std::mem::size_of::<Value>(),
-                        &mut [],
-                    );
+                Opcode::cell_new => {
+                    let opnds = insns::cell_new::decode(insn);
+
+                    self.gc_check(HEADER_SIZE + size_of::<Value>(), &mut []);
 
                     let p_cell = self.alloc.alloc(Value::NIL, Tag::Cell);
-                    push!(Value::cell(p_cell));
+                    set_reg!(opnds.dst, Value::cell(p_cell));
                 }
 
                 // Set the value stored in a mutable cell
-                Insn::cell_set => {
-                    let cell = pop!();
-                    let val = pop!();
+                Opcode::cell_set => {
+                    let opnds = insns::cell_set::decode(insn);
+                    let cell = get_reg!(opnds.cell);
+                    let val = get_reg!(opnds.src);
 
                     match cell.to_cell() {
                         Some(p_cell) => *p_cell = val,
@@ -1916,149 +1835,116 @@ impl Actor
                 }
 
                 // Get the value stored in a mutable cell
-                Insn::cell_get => {
-                    let cell = pop!();
+                Opcode::cell_get => {
+                    let opnds = insns::cell_get::decode(insn);
+                    let cell = get_reg!(opnds.cell);
 
                     let val = match cell.to_cell() {
                         Some(p_cell) => *p_cell,
                         None => error!("cell_get", "invalid cell in cell_get")
                     };
 
-                    push!(val);
+                    set_reg!(opnds.dst, val);
+                }
+
+                Opcode::instanceof => {
+                    let opnds = insns::instanceof::decode(insn);
+                    let val = get_reg!(opnds.val);
+                    let class_id = ClassId::from(opnds.class_id as usize);
+                    set_reg_bool!(opnds.dst, crate::runtime::get_class_id(val) == class_id);
                 }
 
                 // Create new empty dictionary
-                Insn::dict_new => {
-                    self.gc_check(
-                        Dict::alloc_size(0),
-                        &mut []
-                    );
-                    push!(Dict::with_capacity(0, &mut self.alloc))
+                Opcode::dict_new => {
+                    let opnds = insns::dict_new::decode(insn);
+                    self.gc_check(Dict::alloc_size(0), &mut []);
+                    let dict = Dict::with_capacity(0, &mut self.alloc);
+                    set_reg!(opnds.dst, dict);
                 }
 
-                // Set object field
-                Insn::set_field { name, class_id, slot_idx } => {
-                    let val = pop!();
-                    let obj = pop!();
+                // Create new empty array
+                Opcode::arr_new => {
+                    let opnds = insns::arr_new::decode(insn);
+                    let capacity = opnds.capacity as usize;
 
-                    // Fast path: an object of the class this site last
-                    // resolved. Everything else goes out of line, so that
-                    // the interpreter loop carries only this
-                    if let Some(o) = obj.to_obj() {
-                        if class_id == o.class_id {
-                            o.set(slot_idx as usize, val);
-                            continue;
-                        }
-                    }
-
-                    if let Err(msg) = self.set_field_slow(obj, val, name, pc - 1) {
-                        error!("set_field", "{}", msg);
-                    }
+                    self.gc_check(Array::alloc_size(capacity), &mut []);
+                    let arr = Array::with_capacity(capacity, &mut self.alloc);
+                    set_reg!(opnds.dst, arr);
                 }
 
-                // Allocate a new class instance and call
-                // the constructor for the given class
-                Insn::new { class_id, argc } => {
-                    let num_slots = self.get_num_slots(class_id);
-
-                    self.gc_check(
-                        Object::alloc_size(num_slots),
-                        &mut [],
-                    );
-
-                    let obj_val = Object::new(class_id, num_slots, &mut self.alloc);
-
-                    // If a constructor method is present
-                    let init_fun = self.get_method(class_id, "init");
-                    if let Some(fun_id) = init_fun {
-                        let this_pc = pc - 1;
-
-                        // The self value should be first argument to the constructor
-                        // The constructor also returns the allocated object
-                        self.stack.insert(self.stack.len() - argc as usize, obj_val);
-                        let ctor_entry = call_fun!(Value::fun(fun_id), argc + 1);
-
-                        // Patch the instruction to avoid lookups next time
-                        self.insns[this_pc] = Insn::new_known_ctor {
-                            class_id,
-                            argc,
-                            num_slots: num_slots.try_into().unwrap(),
-                            ctor_pc: ctor_entry.entry_pc as u32,
-                            fun_id,
-                            num_locals: ctor_entry.num_locals.try_into().unwrap(),
-                        };
-                    } else {
-                        // Return the allocated object
-                        push!(obj_val);
-                    }
+                // Append an element at the end of an array
+                // This instruction is used to construct array literals
+                Opcode::arr_push => {
+                    let opnds = insns::arr_push::decode(insn);
+                    let arr = get_reg!(opnds.arr);
+                    let val = get_reg!(opnds.val);
+                    crate::array::array_push(self, arr, val).unwrap();
                 }
 
-                Insn::new_known_ctor { class_id, argc, num_slots, ctor_pc, fun_id, num_locals } => {
-                    let num_slots = num_slots as usize;
+                // Clone a bytearray
+                Opcode::ba_clone => {
+                    let opnds = insns::ba_clone::decode(insn);
+                    let mut val = get_reg!(opnds.src);
+                    let ba = unwrap_ba!(val, "ba_clone");
 
-                    self.gc_check(
-                        Object::alloc_size(num_slots),
-                        &mut [],
-                    );
+                    self.gc_check(ByteArray::alloc_size(ba.num_bytes()), &mut [&mut val]);
 
-                    // Allocate the object
-                    let obj_val = Object::new(class_id, num_slots, &mut self.alloc);
-
-                    // The self value should be first argument to the constructor
-                    // The constructor also returns the allocated object
-                    self.stack.insert(self.stack.len() - argc as usize, obj_val);
-
-                    // We add an extra argument for the self value
-                    self.frames.push(StackFrame {
-                        argc: argc + 1,
-                        fun: Value::fun(fun_id),
-                        prev_bp: bp,
-                        ret_addr: pc,
-                    });
-
-                    // The base pointer will point at the first local
-                    bp = self.stack.len();
-                    pc = ctor_pc as usize;
-
-                    // Allocate stack slots for the local variables
-                    self.stack.resize(self.stack.len() + num_locals as usize, Value::NIL);
-                }
-
-                Insn::instanceof { class_id } => {
-                    // Check that the class id matches
-                    let val = pop!();
-                    let id = crate::runtime::get_class_id(val);
-                    push_bool!(id == class_id);
+                    let ba_clone = val.as_ba().clone(&mut self.alloc);
+                    set_reg!(opnds.dst, ba_clone);
                 }
 
                 // Get object field
-                Insn::get_field { name, class_id, slot_idx } => {
-                    let obj = pop!();
+                Opcode::get_field => {
+                    let opnds = insns::get_field::decode(insn);
+                    let obj = get_reg!(opnds.obj);
+                    let cache = &self.prop_caches[opnds.cache as usize];
+                    let (class_id, slot_idx) = (cache.class_id, cache.slot_idx);
 
                     // Fast path: an object of the class this site last
                     // resolved. Everything else goes out of line, so that
                     // the interpreter loop carries only this
                     if let Some(o) = obj.to_obj() {
-                        if class_id == o.class_id {
+                        if o.class_id == class_id {
                             let val = o.get(slot_idx as usize);
 
                             if !val.is_undef() {
-                                push!(val);
+                                set_reg!(opnds.dst, val);
                                 continue;
                             }
                         }
                     }
 
-                    let val = match self.get_field_slow(obj, name, pc - 1) {
+                    let val = match self.get_field_slow(obj, opnds.cache) {
                         Ok(val) => val,
                         Err(msg) => error!("get_field", "{}", msg),
                     };
-                    push!(val);
+                    set_reg!(opnds.dst, val);
                 }
 
-                Insn::get_index => {
-                    let idx = pop!();
-                    let arr = pop!();
+                // Set object field
+                Opcode::set_field => {
+                    let opnds = insns::set_field::decode(insn);
+                    let obj = get_reg!(opnds.obj);
+                    let val = get_reg!(opnds.src);
+                    let cache = &self.prop_caches[opnds.cache as usize];
+                    let (class_id, slot_idx) = (cache.class_id, cache.slot_idx);
+
+                    if let Some(o) = obj.to_obj() {
+                        if o.class_id == class_id {
+                            o.set(slot_idx as usize, val);
+                            continue;
+                        }
+                    }
+
+                    if let Err(msg) = self.set_field_slow(obj, val, opnds.cache) {
+                        error!("set_field", "{}", msg);
+                    }
+                }
+
+                Opcode::get_index => {
+                    let opnds = insns::get_index::decode(insn);
+                    let arr = get_reg!(opnds.arr);
+                    let idx = get_reg!(opnds.idx);
 
                     if !arr.is_heap() {
                         error!("get_index", "expected array or dict type in get_index");
@@ -2087,13 +1973,14 @@ impl Actor
                         _ => error!("get_index", "expected array or dict type in get_index")
                     };
 
-                    push!(val);
+                    set_reg!(opnds.dst, val);
                 }
 
-                Insn::set_index => {
-                    let mut val = pop!();
-                    let mut idx = pop!();
-                    let mut arr = pop!();
+                Opcode::set_index => {
+                    let opnds = insns::set_index::decode(insn);
+                    let mut arr = get_reg!(opnds.arr);
+                    let mut idx = get_reg!(opnds.idx);
+                    let mut val = get_reg!(opnds.src);
 
                     if !arr.is_heap() {
                         error!("set_index", "expected array or dict type");
@@ -2130,108 +2017,154 @@ impl Actor
                     };
                 }
 
-                // Create new empty array
-                Insn::arr_new { capacity } => {
-                    let capacity = capacity as usize;
-
-                    self.gc_check(
-                        Array::alloc_size(capacity),
-                        &mut [],
-                    );
-
-                    push!(Array::with_capacity(capacity, &mut self.alloc))
-                }
-
-                // Append an element at the end of an array
-                // This instruction is used to construct array literals
-                Insn::arr_push => {
-                    let val = pop!();
-                    let array = pop!();
-                    crate::array::array_push(self, array, val).unwrap();
-                }
-
-                // Clone a bytearray
-                Insn::ba_clone => {
-                    let mut val = pop!();
-                    let ba = unwrap_ba!(val, "ba_clone");
-
-                    self.gc_check(
-                        ByteArray::alloc_size(ba.num_bytes()),
-                        &mut [&mut val],
-                    );
-
-                    let ba_clone = val.as_ba().clone(&mut self.alloc);
-                    push!(ba_clone);
-                }
-
                 // Jump if true
-                Insn::if_true { target_ofs } => {
-                    let v = pop!();
+                Opcode::if_true => {
+                    let opnds = insns::if_true::decode(insn);
+                    let v = get_reg!(opnds.val);
 
                     if v.is_true() {
-                        pc = ((pc as i64) + (target_ofs as i64)) as usize;
+                        pc = ((pc as i64) + (opnds.disp as i64)) as usize;
                     } else if !v.is_false() {
                         error!("if_true", "if_true instruction only accepts boolean values");
                     }
                 }
 
                 // Jump if false
-                Insn::if_false { target_ofs } => {
-                    let v = pop!();
+                Opcode::if_false => {
+                    let opnds = insns::if_false::decode(insn);
+                    let v = get_reg!(opnds.val);
 
                     if v.is_false() {
-                        pc = ((pc as i64) + (target_ofs as i64)) as usize;
+                        pc = ((pc as i64) + (opnds.disp as i64)) as usize;
                     } else if !v.is_true() {
                         error!("if_false", "if_false instruction only accepts boolean values");
                     }
                 }
 
+                Opcode::jlt => cmp_branch!(insn, "lt", jlt, <, cmp_lt),
+                Opcode::jle => cmp_branch!(insn, "le", jle, <=, cmp_le),
+                Opcode::jgt => cmp_branch!(insn, "gt", jgt, >, cmp_gt),
+                Opcode::jge => cmp_branch!(insn, "ge", jge, >=, cmp_ge),
+
+                Opcode::jeq => {
+                    let opnds = insns::jeq::decode(insn);
+
+                    if get_reg!(opnds.a) == get_reg!(opnds.b) {
+                        pc = ((pc as i64) + (opnds.disp as i64)) as usize;
+                    }
+                }
+
+                Opcode::jne => {
+                    let opnds = insns::jne::decode(insn);
+
+                    if get_reg!(opnds.a) != get_reg!(opnds.b) {
+                        pc = ((pc as i64) + (opnds.disp as i64)) as usize;
+                    }
+                }
+
                 // Unconditional jump
-                Insn::jump { target_ofs } => {
-                    pc = ((pc as i64) + (target_ofs as i64)) as usize
+                Opcode::jmp => {
+                    let opnds = insns::jmp::decode(insn);
+                    pc = ((pc as i64) + (opnds.disp as i64)) as usize;
                 }
 
-                // call (arg0, arg1, ..., argN, fun)
-                Insn::call { argc } => {
-                    let fun = pop!();
-                    call_fun!(fun, argc);
+                // Call a host function the VM provides
+                Opcode::call_host => {
+                    let opnds = insns::call_host::decode(insn);
+                    let host_fn = HostFnId::from_index(opnds.host_fn).get();
+                    let base = bp + opnds.start_reg as usize;
+
+                    if let Err(msg) = self.call_host(host_fn, base, opnds.argc as usize) {
+                        error!("{}", msg);
+                    }
                 }
 
-                // call_direct (arg0, arg1, ..., argN)
-                Insn::call_direct { fun_id, argc } => {
-                    let this_pc = pc - 1;
-                    let fun_entry = call_fun!(Value::fun(fun_id), argc);
+                // Call a function by id. The callee is statically known,
+                // so this resolves once and becomes a call_pc
+                Opcode::call_direct => {
+                    let opnds = insns::call_direct::decode(insn);
+                    let fun_id = FunId::from(opnds.fun as usize);
+                    let (fun_val, _, entry) = resolve_callee!(Value::fun(fun_id), opnds.argc);
 
-                    // Patch the instruction to jump directly to the entry point next time
-                    self.insns[this_pc] = Insn::call_pc {
-                        entry_pc: fun_entry.entry_pc.try_into().unwrap(),
+                    // The callee cannot change, so the site is rewritten
+                    // rather than guarded
+                    let cache = self.new_call_cache_entry(CallCache {
                         fun_id,
-                        num_locals: fun_entry.num_locals.try_into().unwrap(),
-                        argc
-                    };
-                }
-
-                // call_pc (arg0, arg1, ..., argN)
-                Insn::call_pc { entry_pc, fun_id, num_locals, argc } => {
-                    self.frames.push(StackFrame {
-                        argc,
-                        fun: Value::fun(fun_id),
-                        prev_bp: bp,
-                        ret_addr: pc,
+                        entry_pc: entry.entry_pc as u32,
+                        frame_size: entry.frame_size as u16,
+                        ..CallCache::default()
                     });
+                    self.insns[this_pc] = Insn::call_pc(opnds.start_reg, opnds.argc, cache);
 
-                    // The base pointer will point at the first local
-                    bp = self.stack.len();
-                    pc = entry_pc as usize;
-
-                    // Allocate stack slots for the local variables
-                    self.stack.resize(self.stack.len() + num_locals as usize, Value::NIL);
+                    push_frame!(fun_val, opnds.start_reg, entry.entry_pc, entry.frame_size);
                 }
 
-                // Call a method with a known name
-                // call_method (self, arg0, ..., argN)
-                Insn::call_method { name, argc } => {
-                    let self_val = self.stack[self.stack.len() - (1 + argc as usize)];
+                // Call a function whose entry point is already known
+                Opcode::call_pc => {
+                    let opnds = insns::call_pc::decode(insn);
+                    let cache = &self.call_caches[opnds.cache as usize];
+                    let (fun_id, entry_pc, frame_size) =
+                        (cache.fun_id, cache.entry_pc, cache.frame_size);
+
+                    push_frame!(Value::fun(fun_id), opnds.start_reg, entry_pc, frame_size);
+                }
+
+                // Call a function value. The callee sits just past the
+                // arguments, where this frame will overwrite it
+                Opcode::call_opnd => {
+                    let opnds = insns::call_opnd::decode(insn);
+                    let fun_val = get_reg!(opnds.start_reg as usize + opnds.argc as usize);
+
+                    // A closure and the function it closes over share an
+                    // entry point, so the guard is on the function id and
+                    // the frame records the closure itself
+                    if let Some(fun_id) = fun_val.to_fun_id() {
+                        let cache = &self.call_caches[opnds.cache as usize];
+
+                        if cache.fun_id == fun_id {
+                            let (entry_pc, frame_size) = (cache.entry_pc, cache.frame_size);
+                            push_frame!(fun_val, opnds.start_reg, entry_pc, frame_size);
+                            continue;
+                        }
+                    } else if let Some(f) = fun_val.to_host_fn() {
+                        let base = bp + opnds.start_reg as usize;
+
+                        if let Err(msg) = self.call_host(f, base, opnds.argc as usize) {
+                            error!("{}", msg);
+                        }
+
+                        continue;
+                    }
+
+                    let (fun_val, fun_id, entry) = resolve_callee!(fun_val, opnds.argc);
+
+                    let cache = &mut self.call_caches[opnds.cache as usize];
+                    cache.fun_id = fun_id;
+                    cache.entry_pc = entry.entry_pc as u32;
+                    cache.frame_size = entry.frame_size as u16;
+
+                    push_frame!(fun_val, opnds.start_reg, entry.entry_pc, entry.frame_size);
+                }
+
+                // Call a method on the value in start_reg
+                Opcode::call_method => {
+                    let opnds = insns::call_method::decode(insn);
+                    let self_val = get_reg!(opnds.start_reg);
+
+                    let cache = &self.call_caches[opnds.cache as usize];
+                    let (name, class_id) = (cache.name, cache.class_id);
+
+                    // Guard that self is an object of the class this site
+                    // last looked the method up on
+                    if let Some(obj) = self_val.to_obj() {
+                        if obj.class_id == class_id {
+                            let cache = &self.call_caches[opnds.cache as usize];
+                            let (fun_id, entry_pc, frame_size) =
+                                (cache.fun_id, cache.entry_pc, cache.frame_size);
+                            push_frame!(Value::fun(fun_id), opnds.start_reg, entry_pc, frame_size);
+                            continue;
+                        }
+                    }
 
                     match self_val.to_obj() {
                         Some(obj) => {
@@ -2240,149 +2173,156 @@ impl Actor
                             let class_id = obj.class_id;
 
                             let fun_id = match self.get_method_of(class_id, name) {
-                                None => error!(
-                                    "call to method `{}`, not found on class `{}`",
-                                    self.name_str(name).to_string(),
-                                    self.get_class_name(class_id)
-                                ),
+                                None => {
+                                    let method = self.name_str(name).to_string();
+                                    let class = self.get_class_name(class_id);
+                                    error!("call to method `{}`, not found on class `{}`", method, class)
+                                }
                                 Some(fun_id) => fun_id,
                             };
 
-                            let this_pc = pc - 1;
-                            let fun_entry = call_fun!(Value::fun(fun_id), argc + 1);
+                            let (fun_val, _, entry) = resolve_callee!(Value::fun(fun_id), opnds.argc);
 
-                            // Patch this instruction to avoid the method
-                            // lookup next time
-                            self.insns[this_pc] = Insn::call_method_pc {
-                                name,
-                                argc: argc.try_into().unwrap(),
-                                class_id,
-                                entry_pc: fun_entry.entry_pc.try_into().unwrap(),
-                                fun_id,
-                                num_locals: fun_entry.num_locals.try_into().unwrap(),
-                            };
+                            let cache = &mut self.call_caches[opnds.cache as usize];
+                            cache.class_id = class_id;
+                            cache.fun_id = fun_id;
+                            cache.entry_pc = entry.entry_pc as u32;
+                            cache.frame_size = entry.frame_size as u16;
+
+                            push_frame!(fun_val, opnds.start_reg, entry.entry_pc, entry.frame_size);
                         }
 
                         // Call to a primitive e.g. Int64/Float64/immediate (not an object)
                         None => {
-                            // Lookup the method to call
                             let host_fn = match crate::runtime::get_method(self_val, self.name_str(name)) {
-                                None => error!("call to unknown method `{}`", self.name_str(name)),
+                                None => {
+                                    let method = self.name_str(name).to_string();
+                                    error!("call to unknown method `{}`", method)
+                                }
                                 Some(id) => id,
                             };
-
-                            if argc as usize + 1 > self.stack.len() - bp {
-                                error!("not enough call arguments on stack");
-                            }
 
                             // Patch this instruction to avoid the method
                             // lookup next time. Bools and classes are left
                             // alone because their methods depend on more
-                            // than the type tag. Nothing has allocated since
-                            // the name was read, so it hasn't moved.
+                            // than the type tag.
                             let type_tag = self_val.type_of();
                             if !matches!(type_tag, Type::Bool | Type::Class) {
-                                self.insns[pc - 1] = Insn::call_method_host {
-                                    name,
-                                    argc,
-                                    type_tag,
-                                    host_fn,
-                                };
+                                self.call_caches[opnds.cache as usize].host_fn = host_fn;
+                                self.insns[this_pc] = Insn::call_method_host(
+                                    opnds.start_reg,
+                                    opnds.argc,
+                                    type_tag as u8,
+                                    opnds.cache,
+                                );
                             }
 
-                            if let Err(msg) = self.call_host(host_fn.get(), argc as usize + 1) {
+                            let base = bp + opnds.start_reg as usize;
+
+                            if let Err(msg) = self.call_host(host_fn.get(), base, opnds.argc as usize) {
                                 error!("{}", msg);
                             }
                         }
-                    };
-                }
-
-                Insn::call_method_pc { name, argc, class_id, entry_pc, fun_id, num_locals } => {
-                    let self_val = self.stack[self.stack.len() - (1 + argc as usize)];
-
-                    // Guard that self is an object with a matching class id
-                    if let Some(obj) = self_val.to_obj() {
-                        if obj.class_id == class_id {
-                            let argc: u8 = argc.into();
-                            self.frames.push(StackFrame {
-                                argc: argc + 1,
-                                fun: Value::fun(fun_id),
-                                prev_bp: bp,
-                                ret_addr: pc,
-                            });
-
-                            // The base pointer will point at the first local
-                            bp = self.stack.len();
-                            pc = entry_pc as usize;
-
-                            // Allocate stack slots for the local variables
-                            self.stack.resize(self.stack.len() + num_locals as usize, Value::NIL);
-
-                            // Proceed with the call
-                            continue;
-                        }
                     }
-
-                    // The guard fail, deoptimize this instruction and try again
-                    pc -= 1;
-                    self.insns[pc] = Insn::call_method {
-                        name,
-                        argc: argc.into(),
-                    };
                 }
 
-                Insn::call_method_host { name, argc, type_tag, host_fn } => {
-                    // Checked when the instruction was patched in
-                    debug_assert!(argc as usize + 1 <= self.stack.len() - bp);
-                    let self_val = self.stack[self.stack.len() - (1 + argc as usize)];
+                // Call a host method, guarded on the receiver's type tag
+                Opcode::call_method_host => {
+                    let opnds = insns::call_method_host::decode(insn);
+                    let self_val = get_reg!(opnds.start_reg);
 
                     // Guard that self still has the type the method was found on
-                    if self_val.type_of() == type_tag {
-                        if let Err(msg) = self.call_host(host_fn.get(), argc as usize + 1) {
+                    if self_val.type_of() as u8 == opnds.type_tag {
+                        let host_fn = self.call_caches[opnds.cache as usize].host_fn.get();
+                        let base = bp + opnds.start_reg as usize;
+
+                        if let Err(msg) = self.call_host(host_fn, base, opnds.argc as usize) {
                             error!("{}", msg);
                         }
 
                         continue;
                     }
 
-                    // The guard failed, deoptimize this instruction and try again
-                    pc -= 1;
-                    self.insns[pc] = Insn::call_method { name, argc };
+                    // The guard failed. Both forms take the same operands,
+                    // so deoptimizing is a write of the opcode
+                    self.insns[this_pc] = Insn::call_method(
+                        opnds.start_reg,
+                        opnds.argc,
+                        opnds.cache,
+                    );
+                    pc = this_pc;
                 }
 
-                Insn::ret => {
-                    if self.stack.len() <= bp {
-                        error!("ret", "no return value on stack");
+                // Allocate a class instance and run its constructor
+                Opcode::new => {
+                    let opnds = insns::new::decode(insn);
+                    let class_id = ClassId::from(opnds.class_id as usize);
+                    let num_slots = self.get_num_slots(class_id);
+
+                    self.gc_check(Object::alloc_size(num_slots), &mut []);
+
+                    // The object is the constructor's self argument, and
+                    // also what the call leaves behind as its result
+                    let obj_val = Object::new(class_id, num_slots, &mut self.alloc);
+                    set_reg!(opnds.start_reg, obj_val);
+
+                    let init_fun = self.get_method(class_id, "init");
+
+                    if let Some(fun_id) = init_fun {
+                        let (fun_val, _, entry) = resolve_callee!(Value::fun(fun_id), opnds.argc);
+
+                        // The class is statically known, so the site is
+                        // rewritten rather than guarded
+                        let cache = self.new_call_cache_entry(CallCache {
+                            class_id,
+                            fun_id,
+                            entry_pc: entry.entry_pc as u32,
+                            frame_size: entry.frame_size as u16,
+                            num_slots: num_slots as u16,
+                            ..CallCache::default()
+                        });
+                        self.insns[this_pc] = Insn::new_known_ctor(opnds.start_reg, opnds.argc, cache);
+
+                        push_frame!(fun_val, opnds.start_reg, entry.entry_pc, entry.frame_size);
+                    } else if opnds.argc != 1 {
+                        error!(
+                            "class `{}` has no constructor but was given {} argument(s)",
+                            self.get_class_name(class_id),
+                            opnds.argc - 1,
+                        );
                     }
-
-                    let ret_val = pop!();
-                    //println!("ret_val={:?}", ret_val);
-
-                    // If this is a top-level return
-                    if self.frames.len() == 1 {
-                        self.stack.clear();
-                        self.frames.clear();
-                        return ret_val;
-                    }
-
-                    // The pop below already panics on an empty frame stack
-                    debug_assert!(self.frames.len() > 0);
-                    let top_frame = self.frames.pop().unwrap();
-
-                    // Pop all local variables and arguments
-                    // We pop arguments in the callee so we can support tail calls
-                    let argc = top_frame.argc as usize;
-                    assert!(self.stack.len() >= bp - argc);
-                    self.stack.truncate(bp - argc);
-
-                    pc = top_frame.ret_addr;
-                    bp = top_frame.prev_bp;
-
-                    push!(ret_val);
                 }
 
-                #[allow(unreachable_patterns)]
-                _ => error!("unknown opcode {:?}", insn)
+                // Allocate a class instance whose constructor is known
+                Opcode::new_known_ctor => {
+                    let opnds = insns::new_known_ctor::decode(insn);
+                    let cache = &self.call_caches[opnds.cache as usize];
+                    let (class_id, num_slots) = (cache.class_id, cache.num_slots as usize);
+                    let (fun_id, entry_pc, frame_size) =
+                        (cache.fun_id, cache.entry_pc, cache.frame_size);
+
+                    self.gc_check(Object::alloc_size(num_slots), &mut []);
+
+                    let obj_val = Object::new(class_id, num_slots, &mut self.alloc);
+                    set_reg!(opnds.start_reg, obj_val);
+
+                    push_frame!(Value::fun(fun_id), opnds.start_reg, entry_pc, frame_size);
+                }
+
+                Opcode::ret => {
+                    let opnds = insns::ret::decode(insn);
+                    let ret_val = get_reg!(opnds.src);
+                    do_return!(ret_val);
+                }
+
+                Opcode::ret_nil => {
+                    do_return!(Value::NIL);
+                }
+
+                Opcode::ret_imm32 => {
+                    let opnds = insns::ret_imm32::decode(insn);
+                    do_return!(Value::from_raw_bits(opnds.imm as i64 as u64));
+                }
             }
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -148,9 +148,6 @@ pub enum Insn
     // Unconditional jump
     jump { target_ofs: i32 },
 
-    // Call a host function
-    //call_host { host_fn: HostFn, argc: u8 },
-
     // Call a function using the call stack
     // call (arg0, arg1, ..., argN)
     call { argc: u8 },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,7 +3,6 @@ use std::thread;
 use std::sync::{Arc, Weak, Mutex, mpsc};
 use std::time::Duration;
 use crate::dict::Dict;
-// Only the GC logging below formats numbers this way
 #[cfg(feature = "log_gc")]
 use crate::utils::thousands_sep;
 use crate::lexer::SrcPos;
@@ -61,16 +60,6 @@ pub enum Insn
     // getn 0 is equivalent to dup
     getn { idx: u16 },
 
-    /*
-    // Pop the stack top and set the nth stack slot from the top to this value
-    // setn 0 is equivalent to removing the value below the current stack top
-    // setn <idx:u8>
-    setn,
-
-    // Get the argument count for the current stack frame
-    get_argc,
-    */
-
     // Get the function argument at a given index
     get_arg { idx: u32 },
 
@@ -114,12 +103,6 @@ pub enum Insn
 
     // Logical negation
     not,
-
-    // Type check operations
-    //is_nil,
-    //is_int64,
-    //is_object,
-    //is_array,
 
     // Closure operations
     clos_new { fun_id: FunId, num_slots: u32 },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -13,6 +13,7 @@ use crate::closure::Closure;
 use crate::array::Array;
 use crate::bytearray::ByteArray;
 use crate::codegen::CompiledFun;
+use crate::insns::NameId;
 use crate::gc::{undo_forwarding, Copier, StrTable, UndoLog};
 use crate::host::*;
 use crate::str::Str;
@@ -45,7 +46,9 @@ pub enum Insn
     #[allow(dead_code)]
     nop,
 
-    // Push a value to the stack
+    // Push an immediate value to the stack. Heap values go through
+    // push_const instead, so that the instruction stream holds no
+    // pointers for the collector to chase
     push { val: Value },
 
     // Stack manipulation
@@ -124,8 +127,8 @@ pub enum Insn
     instanceof { class_id: ClassId },
 
     // Get/set field
-    get_field { field: Value, class_id: ClassId, slot_idx: u32 },
-    set_field { field: Value, class_id: ClassId, slot_idx: u32 },
+    get_field { name: NameId, class_id: ClassId, slot_idx: u32 },
+    set_field { name: NameId, class_id: ClassId, slot_idx: u32 },
 
     // Get/set indexed element
     get_index,
@@ -160,16 +163,19 @@ pub enum Insn
 
     // Call a method on an object
     // call_method (self, arg0, ..., argN)
-    call_method { name: Value, argc: u8 },
+    call_method { name: NameId, argc: u8 },
 
     // Call a method with a previously known pc
-    call_method_pc { name: Value, argc: u8, class_id: ClassId, entry_pc: u32, fun_id: FunId, num_locals: u16 },
+    call_method_pc { name: NameId, argc: u8, class_id: ClassId, entry_pc: u32, fun_id: FunId, num_locals: u16 },
 
     // Call a host method on a primitive, guarded on the type tag
-    call_method_host { name: Value, argc: u8, type_tag: Type, host_fn: &'static HostFn },
+    call_method_host { name: NameId, argc: u8, type_tag: Type, host_fn: HostFnId },
 
     // Return
     ret,
+
+    // Push a heap constant from the actor's constant pool
+    push_const { idx: u32 },
 }
 
 // This error macro is to be used inside host functions
@@ -267,6 +273,18 @@ pub struct Actor
 
     // Array of compiled instructions
     pub(crate) insns: Vec<Insn>,
+
+    // Heap constants the compiled code refers to. Instructions hold an
+    // index into this rather than a heap pointer, so the collector traces
+    // the pool and never walks the instruction stream
+    consts: Vec<Value>,
+
+    // Interned field and method names. Instructions name a field or a
+    // method by id; `name_strs` holds the matching heap string, which the
+    // dictionary paths need as a key
+    names: Vec<String>,
+    name_ids: HashMap<String, NameId>,
+    name_strs: Vec<Value>,
 }
 
 /// Why an integer operation produced no result
@@ -379,6 +397,10 @@ impl Actor
             insns: Vec::default(),
             classes: HashMap::default(),
             funs: HashMap::default(),
+            consts: Vec::default(),
+            names: Vec::default(),
+            name_ids: HashMap::default(),
+            name_strs: Vec::default(),
         }
     }
 
@@ -662,36 +684,221 @@ impl Actor
         entry
     }
 
+    /// Cache a copy of a class in this actor, copying it from the parent
+    /// VM the first time it is asked for. Splitting this out from
+    /// `with_class` lets a caller borrow the class alongside something
+    /// else the actor owns, such as an interned name
+    fn load_class(&mut self, class_id: ClassId)
+    {
+        if !self.classes.contains_key(&class_id) {
+            self.copy_class(class_id);
+        }
+    }
+
+    /// Copy a class out of the parent VM. This locks the VM and clones,
+    /// and happens once per class, so it is kept out of line rather than
+    /// inlined into the interpreter at every site that touches a class
+    #[cold]
+    #[inline(never)]
+    fn copy_class(&mut self, class_id: ClassId)
+    {
+        // Borrow the VM and clone the class
+        let vm = self.vm.lock().unwrap();
+
+        // Class ids come from the compiler and from the runtime itself,
+        // so a missing class means we are at fault, not the running program
+        let class = match vm.prog.classes.get(&class_id) {
+            Some(class) => class.clone(),
+            None => panic!("internal error: could not find class with id={:?}", class_id),
+        };
+        drop(vm);
+
+        self.classes.insert(class_id, class);
+    }
+
     /// Compute something requiring access to a class, lazily
     /// copying the class from the parent VM as needed
     pub fn with_class<F, T>(&mut self, class_id: ClassId, f: F) -> T
     where F: FnOnce(&Class) -> T
     {
-        if let Some(class) = self.classes.get(&class_id) {
-            return f(class);
+        self.load_class(class_id);
+        f(&self.classes[&class_id])
+    }
+
+    /// Text of an interned field or method name
+    pub fn name_str(&self, name: NameId) -> &str
+    {
+        &self.names[name as usize]
+    }
+
+    /// Get the slot index for a field named by an interned name
+    fn get_slot_idx_of(&mut self, class_id: ClassId, name: NameId) -> Option<usize>
+    {
+        self.load_class(class_id);
+        self.classes[&class_id].fields.get(self.name_str(name)).copied()
+    }
+
+    /// Get the function id of a method named by an interned name
+    fn get_method_of(&mut self, class_id: ClassId, name: NameId) -> Option<FunId>
+    {
+        self.load_class(class_id);
+        self.classes[&class_id].methods.get(self.name_str(name)).copied()
+    }
+
+    /// Resolve a field read the cached path did not handle: a dict, an
+    /// array, a string, or an object of a class this site has not seen.
+    /// Kept out of line so that the interpreter loop carries only the
+    /// cached case
+    #[inline(never)]
+    fn get_field_slow(&mut self, obj: Value, name: NameId, insn_pc: usize) -> Result<Value, String>
+    {
+        if !obj.is_heap() {
+            return Err(format!("get_field on non-object value {:?}", obj));
         }
 
-        // Borrow the VM and clone the class
-        let vm = self.vm.lock().unwrap();
+        // The block header says what the value points at, so one load
+        // and one switch settle the type
+        match obj.heap_tag() {
+            Tag::Object => {
+                let o = obj.as_obj();
 
-        let class = vm.prog.classes.get(&class_id);
+                let slot_idx = match self.get_slot_idx_of(o.class_id, name) {
+                    Some(slot_idx) => slot_idx,
+                    None => {
+                        let class_name = self.get_class_name(o.class_id);
+                        let field_names = self.get_field_names(o.class_id);
+                        return Err(format!(
+                            "class `{}` has no field `{}`, known fields are: {}",
+                            class_name,
+                            self.name_str(name),
+                            field_names,
+                        ));
+                    }
+                };
 
-        // Class ids come from the compiler and from the runtime itself,
-        // so a missing class means we are at fault, not the running program
-        if class.is_none() {
-            panic!("internal error: could not find class with id={:?}", class_id);
+                // Update the cache
+                self.insns[insn_pc] = Insn::get_field {
+                    name,
+                    class_id: o.class_id,
+                    slot_idx: slot_idx as u32,
+                };
+
+                let val = o.get(slot_idx);
+
+                if val.is_undef() {
+                    return Err(format!("object field not initialized `{}`", self.name_str(name)));
+                }
+
+                Ok(val)
+            }
+
+            Tag::Dict => {
+                let key = self.name_str(name);
+
+                match obj.as_dict().get(key) {
+                    Some(v) => Ok(v),
+                    None => Err(format!("key '{}' not found in dict", key))
+                }
+            }
+
+            Tag::Array => {
+                match self.name_str(name) {
+                    "len" => Ok(Value::fixnum(obj.as_arr().len() as i64)),
+                    _ => Err("field not found on array".to_string())
+                }
+            }
+
+            Tag::ByteArray => {
+                match self.name_str(name) {
+                    "len" => Ok(Value::fixnum(obj.as_ba().num_bytes() as i64)),
+                    _ => Err("field not found on bytearray".to_string())
+                }
+            }
+
+            Tag::Str => {
+                match self.name_str(name) {
+                    "len" => Ok(Value::fixnum(obj.as_str().len() as i64)),
+                    _ => Err("field not found on string".to_string())
+                }
+            }
+
+            _ => Err(format!("get_field on non-object value {:?}", obj))
+        }
+    }
+
+    /// Resolve a field write the cached path did not handle: a dict, or
+    /// an object of a class this site has not seen
+    #[inline(never)]
+    fn set_field_slow(&mut self, mut obj: Value, mut val: Value, name: NameId, insn_pc: usize)
+        -> Result<(), String>
+    {
+        if let Some(o) = obj.to_obj() {
+            let slot_idx = match self.get_slot_idx_of(o.class_id, name) {
+                Some(slot_idx) => slot_idx,
+                None => {
+                    let class_name = self.get_class_name(o.class_id);
+                    let field_names = self.get_field_names(o.class_id);
+                    return Err(format!(
+                        "class `{}` has no field `{}`, known fields are: {}",
+                        class_name,
+                        self.name_str(name),
+                        field_names,
+                    ));
+                }
+            };
+
+            // Update the cache
+            self.insns[insn_pc] = Insn::set_field {
+                name,
+                class_id: o.class_id,
+                slot_idx: slot_idx as u32,
+            };
+
+            o.set(slot_idx, val);
+            return Ok(());
         }
 
-        let class = class.unwrap().clone();
-        drop(vm);
+        if obj.is_dict() {
+            let alloc_size = obj.as_dict().will_allocate();
+            self.gc_check(alloc_size, &mut [&mut obj, &mut val]);
 
-        let ret = f(&class);
+            // Read after the check: the collector moves the interned
+            // name along with everything else
+            let key = self.name_strs[name as usize];
+            obj.as_dict().set(key.as_string() as *const Str, val, &mut self.alloc);
+            return Ok(());
+        }
 
-        // Save a cached copy of the class to avoid
-        // locking if needed again
-        self.classes.insert(class_id, class);
+        Err("set_field on non-object/dict value".to_string())
+    }
 
-        ret
+    /// Add a heap constant to this actor's pool and return its index.
+    /// The pool is a GC root, so a constant is safe to hold from the
+    /// moment it lands here
+    pub fn push_const(&mut self, val: Value) -> u32
+    {
+        debug_assert!(val.is_heap());
+        self.consts.push(val);
+        (self.consts.len() - 1) as u32
+    }
+
+    /// Intern a field or method name. The heap string a name needs as a
+    /// dict key is allocated once, when the name is first seen, and is
+    /// rooted from then on
+    pub fn intern_name(&mut self, name: &str) -> NameId
+    {
+        if let Some(id) = self.name_ids.get(name) {
+            return *id;
+        }
+
+        self.gc_check(Str::alloc_size(name.len()), &mut []);
+        let val = Str::new(name, &mut self.alloc);
+
+        let id = self.names.len() as NameId;
+        self.names.push(name.to_string());
+        self.name_ids.insert(name.to_string(), id);
+        self.name_strs.push(val);
+        id
     }
 
     /// Get the class name for a given class
@@ -850,20 +1057,14 @@ impl Actor
                 frame.fun = copier.forward(frame.fun);
             }
 
-            // Heap values referenced in instructions
-            for insn in &mut self.insns {
-                match insn {
-                    Insn::push { val } |
-                    Insn::get_field { field: val, .. } |
-                    Insn::set_field { field: val, .. } |
-                    Insn::call_method { name: val, .. } |
-                    Insn::call_method_pc { name: val, .. } |
-                    Insn::call_method_host { name: val, .. } => {
-                        *val = copier.forward(*val);
-                    }
-
-                    _ => {}
-                }
+            // Constants and interned names the compiled code refers to.
+            // Instructions index into these, so the instruction stream
+            // itself holds nothing the collector has to look at
+            for val in &mut self.consts {
+                *val = copier.forward(*val);
+            }
+            for val in &mut self.name_strs {
+                *val = copier.forward(*val);
             }
 
             // Extra roots supplied by the user
@@ -1400,7 +1601,13 @@ impl Actor
                 }
 
                 Insn::push { val } => {
+                   debug_assert!(!val.is_heap());
                    self.stack.push(val);
+                }
+
+                Insn::push_const { idx } => {
+                    let val = self.consts[idx as usize];
+                    self.stack.push(val);
                 }
 
                 Insn::dup => {
@@ -1730,52 +1937,22 @@ impl Actor
                 }
 
                 // Set object field
-                Insn::set_field { field, class_id, slot_idx } => {
-                    let mut val = pop!();
-                    let mut obj = pop!();
+                Insn::set_field { name, class_id, slot_idx } => {
+                    let val = pop!();
+                    let obj = pop!();
 
-                    if let Some(obj) = obj.to_obj() {
-                        if class_id == obj.class_id {
-                            obj.set(slot_idx as usize, val);
-                        } else {
-                            let slot_idx = match self.get_slot_idx(obj.class_id, field.as_str()) {
-                                Some(slot_idx) => slot_idx,
-                                None => error!(
-                                    "set_field",
-                                    "class `{}` has no field `{}`, known fields are: {}",
-                                    self.get_class_name(obj.class_id),
-                                    field.as_str(),
-                                    self.get_field_names(obj.class_id),
-                                )
-                            };
-                            let class_id = obj.class_id;
-
-                            // Update the cache
-                            self.insns[pc - 1] = Insn::set_field {
-                                field,
-                                class_id,
-                                slot_idx: slot_idx as u32,
-                            };
-
-                            obj.set(slot_idx, val);
+                    // Fast path: an object of the class this site last
+                    // resolved. Everything else goes out of line, so that
+                    // the interpreter loop carries only this
+                    if let Some(o) = obj.to_obj() {
+                        if class_id == o.class_id {
+                            o.set(slot_idx as usize, val);
+                            continue;
                         }
                     }
-                    else if obj.is_dict() {
-                        let alloc_size = obj.as_dict().will_allocate();
 
-                        // The field name is reachable from the instruction
-                        // stream, which the collector updates, so it has to
-                        // be read back after the check
-                        let mut field = field;
-                        self.gc_check(
-                            alloc_size,
-                            &mut [&mut obj, &mut val, &mut field]
-                        );
-
-                        obj.as_dict().set(field.as_string() as *const Str, val, &mut self.alloc);
-                    }
-                    else {
-                        error!("set_field", "set_field on non-object/dict value")
+                    if let Err(msg) = self.set_field_slow(obj, val, name, pc - 1) {
+                        error!("set_field", "{}", msg);
                     }
                 }
 
@@ -1855,85 +2032,27 @@ impl Actor
                 }
 
                 // Get object field
-                Insn::get_field { field, class_id, slot_idx } => {
+                Insn::get_field { name, class_id, slot_idx } => {
                     let obj = pop!();
 
-                    if !obj.is_heap() {
-                        error!("get_field", "get_field on non-object value {:?}", obj);
+                    // Fast path: an object of the class this site last
+                    // resolved. Everything else goes out of line, so that
+                    // the interpreter loop carries only this
+                    if let Some(o) = obj.to_obj() {
+                        if class_id == o.class_id {
+                            let val = o.get(slot_idx as usize);
+
+                            if !val.is_undef() {
+                                push!(val);
+                                continue;
+                            }
+                        }
                     }
 
-                    // The block header says what the value points at, so
-                    // one load and one switch settle the type
-                    let val = match obj.heap_tag() {
-                        Tag::Object => {
-                            let obj = obj.as_obj();
-
-                            // If the class id doesn't match the cache, update it
-                            let val = if class_id == obj.class_id {
-                                obj.get(slot_idx as usize)
-                            } else {
-                                let slot_idx = match self.get_slot_idx(obj.class_id, field.as_str()) {
-                                    Some(slot_idx) => slot_idx,
-                                    None => error!(
-                                        "get_field",
-                                        "class `{}` has no field `{}`, known fields are: {}",
-                                        self.get_class_name(obj.class_id),
-                                        field.as_str(),
-                                        self.get_field_names(obj.class_id),
-                                    )
-                                };
-                                let class_id = obj.class_id;
-
-                                // Update the cache
-                                self.insns[pc - 1] = Insn::get_field {
-                                    field,
-                                    class_id,
-                                    slot_idx: slot_idx as u32,
-                                };
-
-                                obj.get(slot_idx as usize)
-                            };
-
-                            if val.is_undef() {
-                                error!("get_field", "object field not initialized `{}`", field.as_str());
-                            }
-
-                            val
-                        }
-
-                        Tag::Dict => {
-                            let key = field.as_str();
-
-                            match obj.as_dict().get(key) {
-                                Some(v) => v,
-                                None => error!("get_field", "key '{}' not found in dict", key)
-                            }
-                        }
-
-                        Tag::Array => {
-                            match field.as_str() {
-                                "len" => Value::fixnum(obj.as_arr().len() as i64),
-                                _ => error!("get_field", "field not found on array")
-                            }
-                        }
-
-                        Tag::ByteArray => {
-                            match field.as_str() {
-                                "len" => Value::fixnum(obj.as_ba().num_bytes() as i64),
-                                _ => error!("get_field", "field not found on bytearray")
-                            }
-                        }
-
-                        Tag::Str => {
-                            match field.as_str() {
-                                "len" => Value::fixnum(obj.as_str().len() as i64),
-                                _ => error!("get_field", "field not found on string")
-                            }
-                        }
-
-                        _ => error!("get_field", "get_field on non-object value {:?}", obj)
+                    let val = match self.get_field_slow(obj, name, pc - 1) {
+                        Ok(val) => val,
+                        Err(msg) => error!("get_field", "{}", msg),
                     };
-
                     push!(val);
                 }
 
@@ -2120,10 +2239,10 @@ impl Actor
                             // the callee and collect, leaving obj behind
                             let class_id = obj.class_id;
 
-                            let fun_id = match self.get_method(class_id, name.as_str()) {
+                            let fun_id = match self.get_method_of(class_id, name) {
                                 None => error!(
                                     "call to method `{}`, not found on class `{}`",
-                                    name.as_str(),
+                                    self.name_str(name).to_string(),
                                     self.get_class_name(class_id)
                                 ),
                                 Some(fun_id) => fun_id,
@@ -2132,15 +2251,8 @@ impl Actor
                             let this_pc = pc - 1;
                             let fun_entry = call_fun!(Value::fun(fun_id), argc + 1);
 
-                            // Patch this instruction to avoid the method lookup
-                            // next time. The name is read back out of the
-                            // instruction rather than reused, since a collection
-                            // in the call above would have moved the string.
-                            let name = match self.insns[this_pc] {
-                                Insn::call_method { name, .. } => name,
-                                _ => panic!("call_method instruction expected")
-                            };
-
+                            // Patch this instruction to avoid the method
+                            // lookup next time
                             self.insns[this_pc] = Insn::call_method_pc {
                                 name,
                                 argc: argc.try_into().unwrap(),
@@ -2154,11 +2266,9 @@ impl Actor
                         // Call to a primitive e.g. Int64/Float64/immediate (not an object)
                         None => {
                             // Lookup the method to call
-                            let fun = crate::runtime::get_method(self_val, name.as_str());
-
-                            let host_fn = match fun.to_host_fn() {
-                                None => error!("call to unknown method `{}`", name.as_str()),
-                                Some(f) => f,
+                            let host_fn = match crate::runtime::get_method(self_val, self.name_str(name)) {
+                                None => error!("call to unknown method `{}`", self.name_str(name)),
+                                Some(id) => id,
                             };
 
                             if argc as usize + 1 > self.stack.len() - bp {
@@ -2180,7 +2290,7 @@ impl Actor
                                 };
                             }
 
-                            if let Err(msg) = self.call_host(host_fn, argc as usize + 1) {
+                            if let Err(msg) = self.call_host(host_fn.get(), argc as usize + 1) {
                                 error!("{}", msg);
                             }
                         }
@@ -2228,7 +2338,7 @@ impl Actor
 
                     // Guard that self still has the type the method was found on
                     if self_val.type_of() == type_tag {
-                        if let Err(msg) = self.call_host(host_fn, argc as usize + 1) {
+                        if let Err(msg) = self.call_host(host_fn.get(), argc as usize + 1) {
                             error!("{}", msg);
                         }
 

--- a/tests/inline_caches.psh
+++ b/tests/inline_caches.psh
@@ -1,0 +1,49 @@
+// Exercise the inline caches by making each kind of site see more than
+// one thing, so that it has to re-resolve or deoptimize
+
+// A host method site that sees more than one type tag. Resolving turns
+// it into call_method_host, and each new tag deoptimizes it back
+fun show(x) { return x.to_s(); }
+let var acc = "";
+for (let var i = 0; i < 6; i = i + 1) {
+    if (i % 3 == 0) { acc = acc + show(7); }
+    else if (i % 3 == 1) { acc = acc + show(2.5); }
+    else { acc = acc + show("s"); }
+}
+assert(acc == "72.5s72.5s");
+
+// A dynamic call site that resolves to two different closures. They
+// share an entry point, so the guard is on the function they close over
+fun mk(n) { return |x| x + n; }
+fun pick(i, a, b) { if (i % 2 == 0) { return a; } return b; }
+let add10 = mk(10);
+let add100 = mk(100);
+let var total = 0;
+for (let var i = 0; i < 4; i = i + 1) {
+    let f = pick(i, add10, add100);
+    total = total + f(1);
+}
+assert(total == 2 * 11 + 2 * 101);
+
+// A field site that sees two classes, where the field is at a different
+// slot in each
+class P { init(s) { s.v = 1; } }
+class Q { init(s) { s.w = 0; s.v = 2; } }
+fun get_v(o) { return o.v; }
+fun set_v(o, x) { o.v = x; return o.v; }
+let var sum = 0;
+for (let var i = 0; i < 4; i = i + 1) {
+    let o = (i % 2 == 0)? P():Q();
+    sum = sum + get_v(o) + set_v(o, 10);
+}
+assert(sum == 6 + 40);
+
+// A method site that sees an object and then a primitive
+class R { init(s) {} to_s(s) { return "R"; } }
+assert(show(R()) == "R");
+assert(show(42) == "42");
+assert(show(R()) == "R");
+
+// Fields on the built-in types, which resolve by name rather than slot
+assert("abc".len == 3);
+assert([1, 2].len == 2);


### PR DESCRIPTION
Not yet fully optimized, but all I have to say is DAYUMMMMM!

```
benchmark             stack      reg    delta
mlp                  1.677s   0.667s   -60.2%
quicksort            0.856s   0.383s   -55.2%
sha256               3.284s   1.581s   -51.8%
nbody                2.146s   1.088s   -49.3%
fft                  2.842s   1.481s   -47.9%
obj_get              1.256s   0.672s   -46.5%
arr_get              0.671s   0.360s   -46.3%
alloc_objs           2.868s   1.562s   -45.6%
raster_tex           2.975s   1.628s   -45.3%
raster_quad          2.198s   1.210s   -44.9%
gc_alloc_speed       1.518s   0.851s   -43.9%
for_loop             0.943s   0.559s   -40.7%
linked_list          0.591s   0.353s   -40.3%
raster_tri           3.544s   2.126s   -40.0%
matrix_vec_mult      2.272s   1.363s   -40.0%
fib                  1.502s   1.104s   -26.5%
binary_tree          1.122s   0.939s   -16.3%
host_calls           0.409s   0.345s   -15.6%
gc_obj_graph         3.105s   2.831s    -8.8%
ping_pong            3.834s   3.722s    -2.9%
gc_many_objs         5.147s   5.083s    -1.3%
gc_large_heap        2.548s   2.560s    +0.5%
TOTAL               47.308s  32.469s   -31.4%
```